### PR TITLE
fix: typo in 'Create TD' dialog

### DIFF
--- a/src/components/App/AppHeader/CreateNewTD.js
+++ b/src/components/App/AppHeader/CreateNewTD.js
@@ -29,7 +29,7 @@ export default async function CreateNewTD() {
         progressSteps: ['1', '2', '3']
     }).queue([
         {
-            title: 'TD Indentifiers',
+            title: 'TD Identifiers',
             html: newTd.RequestTdMetadata(),
             input: null,
             preConfirm: () => {


### PR DESCRIPTION
Fixes the typo in the 'Create TD' dialog.

Closes #11 