### PR TITLE
fix: removing the double arrows in safari browser

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -65,6 +65,8 @@ details[open]>summary::before {
 
 summary {list-style: none}
 
+summary::-webkit-details-marker {display: none;}
+
 details>summary::marker {
   display: none;
 }

--- a/src/components/Dialogs/AddLinkTdDialog.jsx
+++ b/src/components/Dialogs/AddLinkTdDialog.jsx
@@ -16,6 +16,10 @@
  import {hasLinks,checkIfLinkIsInItem,getFileHandle,getFileHTML5,_readFileHTML5} from "../../util.js";
  import { DialogTemplate } from "./DialogTemplate";
 
+ let error = "";
+ let tdJSON = {};
+ let oldtdJSON = {};
+
  export const AddLinkTdDialog = forwardRef((props, ref) => {
      const context = useContext(ediTDorContext);
      const [display, setDisplay] = React.useState(() => { return false });
@@ -24,7 +28,15 @@
 
 
      const interaction = props.interaction ?? {};
-     const offlineTD = JSON.parse(context.offlineTD)
+     try {
+      oldtdJSON = tdJSON;
+      tdJSON = JSON.parse(context.offlineTD);
+      error = '';
+     } catch (e) {
+      error = e.message;
+      console.log(error)
+      tdJSON = oldtdJSON;
+     }
 
      useImperativeHandle(ref, () => {
          return {
@@ -122,7 +134,7 @@
      const children = <>
          <label className="text-sm text-gray-400 font-medium pl-3">Thing Description:</label>
          <div className="p-1">
-                {offlineTD["title"]}
+                {tdJSON["title"]}
          </div>
          <div className="p-1 pt-2">
              <label htmlFor="rel" className="text-sm text-gray-400 font-medium pl-2">Relation:</label>
@@ -239,7 +251,7 @@
                  submitText={"Add"}
                  children={children}
                  title={`Add Link `}
-                 description={`Tell us how this ${offlineTD.title} can interact with other ressources`}
+                 description={`Tell us how this ${tdJSON.title} can interact with other ressources`}
              />,
              document.getElementById("modal-root"));
      }

--- a/src/components/TDViewer/TDViewer.jsx
+++ b/src/components/TDViewer/TDViewer.jsx
@@ -76,7 +76,12 @@ export default function TDViewer() {
         });
         let offlineTD={}
         if(context.offlineTD){
+            try{
             offlineTD = JSON.parse(context.offlineTD)
+            }catch(e){
+                let error = e.message;
+                console.log(error)
+            }
         }
         // Check if the links section exists to start drawing
         //Update/refresh the content of the context.linkedTd whenever the the useEffect is triggered

--- a/src/context/editorReducers.js
+++ b/src/context/editorReducers.js
@@ -26,12 +26,29 @@ export const UPDATE_LINKED_TD = 'UPDATE_LINKED_TD'
 
 const updateOfflineTDReducer = (offlineTD, state) => {
   let linkedTd=state.linkedTd
-  if(linkedTd&& typeof state.fileHandle !== "object"){
-    let parsedTd=JSON.parse(offlineTD)
-    if(document.getElementById("linkedTd")){
-      let href= document.getElementById("linkedTd").value
+  try{
+    //If the user write Thing description without wizard, we save it in linkedTd
+    if(!linkedTd){
+      let parsedTd=JSON.parse(offlineTD)
+      linkedTd={}
+      let href=parsedTd["title"]||"ediTDor Thing"
       linkedTd[href]=parsedTd
     }
+    else if(linkedTd&& typeof state.fileHandle !== "object"){
+      let parsedTd=JSON.parse(offlineTD)
+      if(document.getElementById("linkedTd")){
+        let href= document.getElementById("linkedTd").value
+        if(href===""){
+        linkedTd[parsedTd["title"]||"ediTDor Thing"]=parsedTd
+        }
+        else{
+          linkedTd[href]=parsedTd
+        }
+      }
+    }
+  }catch(e){
+    let error = e.message;
+    console.log(error)
   }
   return { ...state, offlineTD, isModified: true, linkedTd:linkedTd };
 };


### PR DESCRIPTION
- Removing the double arrows in safari browser