### PR TITLE
support directed strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "resolve-url-loader": "^3.1.2",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
+    "string-direction": "^0.1.2",
     "style-loader": "0.23.1",
     "tailwindcss": "^2.0.3",
     "ts-pnp": "1.1.6",

--- a/src/components/TDViewer/RenderedObject.jsx
+++ b/src/components/TDViewer/RenderedObject.jsx
@@ -10,9 +10,11 @@
  * 
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useCallback, useState } from 'react';
+import React, { useContext, useCallback, useState } from 'react';
+import ediTDorContext from '../../context/ediTDorContext';
 import "../../assets/main.css"
 import { ChevronRight, ChevronDown } from 'react-feather';
+import { getDirectedValue } from '../../util';
 
 function isObject(val) {
     if (val === null) { return false; }
@@ -20,6 +22,7 @@ function isObject(val) {
 }
 
 export const RenderedObject = (map) => {
+    const context = useContext(ediTDorContext);
     const [showChildren, setShowChildren] = useState(new Array(Object.entries(map).length));
     const handleClick = useCallback((i) => {
         let temp = showChildren;
@@ -58,10 +61,13 @@ export const RenderedObject = (map) => {
                     )
                 }
 
+                const value = getDirectedValue(map, k,
+                    context.linkedTd[Object.keys(context.linkedTd)[0]]['@context']
+                );
                 return (
                     <div className="flex mb-1" key={i}>
                         <h4 className="text-white font-bold bg-gray-600 py-1 px-2 rounded-md">{k}</h4>
-                        <div className="text-gray-400 px-2 py-1">{`${v}`}</div>
+                        <div className="text-gray-400 px-2 py-1">{value}</div>
                     </div>
                 )
             })}

--- a/src/components/TDViewer/TDViewer.jsx
+++ b/src/components/TDViewer/TDViewer.jsx
@@ -13,7 +13,7 @@
 import React, { useContext, useEffect } from 'react';
 import '../../assets/main.css';
 import ediTDorContext from '../../context/ediTDorContext';
-import { buildAttributeListObject, separateForms, changeBetweenTd } from '../../util';
+import { buildAttributeListObject, separateForms, changeBetweenTd, getDirectedValue } from '../../util';
 import { AddFormDialog } from "../Dialogs/AddFormDialog";
 import { AddLinkTdDialog } from '../Dialogs/AddLinkTdDialog';
 import { InfoIconWrapper } from '../InfoIcon/InfoIcon';
@@ -261,10 +261,10 @@ export default function TDViewer() {
                     </div>))}
                 {(metaData !== undefined && Object.keys(metaData).length > 0) && (
                     <div>
-                        <div className="text-3xl text-white">{metaData.title}</div>
+                        <div className="text-3xl text-white">{getDirectedValue(metaData, 'title', metaData['@context'])}</div>
                         <RenderedObject {...attributeListObject}></RenderedObject>
                         {
-                            metaData.description ? <div className="text-xl text-white pt-4">{metaData.description}</div> : <></>
+                            metaData.description ? <div className="text-xl text-white pt-4">{getDirectedValue(metaData, 'description', metaData['@context'])}</div> : <></>
                         }
                     </div>)
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ import './index.css'
 import App from './components/App/App';
 import * as serviceWorker from './serviceWorker';
 
+require('string-direction').patch();
+
 ReactDOM.render(
   <React.StrictMode>
     <App />

--- a/src/util.js
+++ b/src/util.js
@@ -243,3 +243,191 @@ export const _readFileHTML5 = (file) => {
         reader.readAsText(file);
     });
 }
+
+/**
+ * @param {*} source Source object
+ * @param {string} key Source key
+ * @param {*} atContext Respective @context value
+ * 
+ * @returns {string} String value of source[key] with prepended LRI or RLI symbol
+ *
+ * @description
+ * Returns the value of source[key] with the direction information (rtl/ltr).
+ */
+export const getDirectedValue = (source, key, atContext) => {
+    const LRI = '\u2066';
+    const RLI = '\u2067';
+    const TABLE = {
+      ar: 'rtl',
+      fa: 'rtl',
+      ps: 'rtl',
+      ur: 'rtl',
+      hy: 'ltr',
+      as: 'ltr',
+      bn: 'ltr',
+      zb: 'ltr',
+      ab: 'ltr',
+      be: 'ltr',
+      bg: 'ltr',
+      kk: 'ltr',
+      mk: 'ltr',
+      ru: 'ltr',
+      uk: 'ltr',
+      hi: 'ltr',
+      mr: 'ltr',
+      ne: 'ltr',
+      ko: 'ltr',
+      ma: 'ltr',
+      am: 'ltr',
+      ti: 'ltr',
+      ka: 'ltr',
+      el: 'ltr',
+      gu: 'ltr',
+      pa: 'ltr',
+      he: 'rtl',
+      iw: 'rtl',
+      yi: 'rtl',
+      ja: 'ltr',
+      km: 'ltr',
+      kn: 'ltr',
+      lo: 'ltr',
+      af: 'ltr',
+      ay: 'ltr',
+      bs: 'ltr',
+      ca: 'ltr',
+      ch: 'ltr',
+      cs: 'ltr',
+      cy: 'ltr',
+      da: 'ltr',
+      de: 'ltr',
+      en: 'ltr',
+      eo: 'ltr',
+      es: 'ltr',
+      et: 'ltr',
+      eu: 'ltr',
+      fi: 'ltr',
+      fj: 'ltr',
+      fo: 'ltr',
+      fr: 'ltr',
+      fy: 'ltr',
+      ga: 'ltr',
+      gl: 'ltr',
+      gn: 'ltr',
+      gv: 'ltr',
+      hr: 'ltr',
+      ht: 'ltr',
+      hu: 'ltr',
+      id: 'ltr',
+      in: 'ltr',
+      is: 'ltr',
+      it: 'ltr',
+      kl: 'ltr',
+      la: 'ltr',
+      lb: 'ltr',
+      ln: 'ltr',
+      lt: 'ltr',
+      lv: 'ltr',
+      mg: 'ltr',
+      mh: 'ltr',
+      mo: 'ltr',
+      ms: 'ltr',
+      mt: 'ltr',
+      na: 'ltr',
+      nb: 'ltr',
+      nd: 'ltr',
+      nl: 'ltr',
+      nn: 'ltr',
+      no: 'ltr',
+      nr: 'ltr',
+      ny: 'ltr',
+      om: 'ltr',
+      pl: 'ltr',
+      pt: 'ltr',
+      qu: 'ltr',
+      rm: 'ltr',
+      rn: 'ltr',
+      ro: 'ltr',
+      rw: 'ltr',
+      sg: 'ltr',
+      sk: 'ltr',
+      sl: 'ltr',
+      sm: 'ltr',
+      so: 'ltr',
+      sq: 'ltr',
+      ss: 'ltr',
+      st: 'ltr',
+      sv: 'ltr',
+      sw: 'ltr',
+      tl: 'ltr',
+      tn: 'ltr',
+      to: 'ltr',
+      tr: 'ltr',
+      ts: 'ltr',
+      ve: 'ltr',
+      vi: 'ltr',
+      xh: 'ltr',
+      zu: 'ltr',
+      ds: 'ltr',
+      gs: 'ltr',
+      hs: 'ltr',
+      me: 'ltr',
+      ni: 'ltr',
+      ns: 'ltr',
+      te: 'ltr',
+      tk: 'ltr',
+      tm: 'ltr',
+      tp: 'ltr',
+      tv: 'ltr',
+      ml: 'ltr',
+      my: 'ltr',
+      nq: 'ltr',
+      or: 'ltr',
+      si: 'ltr',
+      ta: 'ltr',
+      dv: 'rtl',
+      th: 'ltr',
+      dz: 'ltr'
+    };
+
+    const getDirectionSymbol = dir => (dir === 'ltr') ? LRI : RLI;
+
+    // title, description and language tags (like "en" or "en-US") are treated differently
+    if (!['title', 'description'].includes(key) && !/^[A-Za-z]{2}(-[A-Za-z]{2})?$/.test(key)) {
+      return getDirectionSymbol(source[key].toString().getDirection()) + source[key];
+    }
+
+    if (/^[A-Za-z]{2}(-[A-Za-z]{2})?$/.test(key)) {
+      // Language tags can be compound like ar-EG or en-US, split when needed
+      // Also, we ignore the case for language tags
+      const lookupKey = (key.includes('-')) ? key.split('-')[0] : key.toLowerCase();
+      const dir = TABLE[lookupKey];
+      if (dir) return getDirectionSymbol(dir) + source[key];
+      return getDirectionSymbol('ltr') + source[key];
+    }
+
+    let direction;
+    let lang;
+
+    if (!Array.isArray(atContext)) {
+      atContext = [atContext];
+    }
+
+    atContext.forEach(e => {
+      if (typeof e === 'object') {
+        if (e['@direction']) direction = e['@direction'];
+        if (e['@language']) lang = e['@language'];
+      }
+    });
+
+    if (key === 'title' || key === 'description') {
+      if (direction) return getDirectionSymbol(direction) + source[key];
+      if (lang) {
+        const lookupKey = (lang.includes('-')) ? lang.split('-')[0] : lang.toLowerCase();
+        const dir = TABLE[lookupKey];
+        if (dir) return getDirectionSymbol(dir) + source[key];
+        return getDirectionSymbol('ltr') + source[key];
+      }
+    }
+
+    return getDirectionSymbol(source[key].toString().getDirection()) + source[key];
+}


### PR DESCRIPTION
In the playground, we had [an issue](https://github.com/thingweb/thingweb-playground/issues/384) regarding string direction assertions.
The issue applies to ediTDor as well, since it "visualizes" the structure of a TD in the right pane.
So, this PR fixes that problem.

<details>
<summary>A TD to test</summary>

```
{
    "id": "urn:simpleWithDefaults",
    "@context": [
        "https://www.w3.org/2022/wot/td/v1.1",
        {
            "@language": "ar-EG",
            "@direction": "rtl"
        }
    ],
    "title": "hello.",
    "description": "شيء يقيس درجة الحرارة و يظهر حالته",
    "descriptions": {
        "ar": "desc."
    },
    "securityDefinitions": {
        "basic_sc": {
            "scheme": "basic",
            "in": "header"
        }
    },
    "security": [
        "basic_sc"
    ],
    "properties": {
        "status": {
            "type": "string",
            "readOnly": true,
            "writeOnly": false,
            "observable": false,
            "forms": [
                {
                    "href": "https://mylamp.example.com/status",
                    "op": "readproperty",
                    "contentType": "application/json"
                }
            ]
        }
    },
    "actions": {
        "toggle": {
            "safe": false,
            "idempotent": false,
            "forms": [
                {
                    "href": "https://mylamp.example.com/toggle",
                    "op": "invokeaction",
                    "contentType": "application/json"
                }
            ]
        }
    },
    "events": {
        "overheating": {
            "data": {
                "type": "string",
                "readOnly": true,
                "writeOnly": false
            },
            "forms": [
                {
                    "href": "https://mylamp.example.com/oh",
                    "op": "subscribeevent",
                    "subprotocol": "longpoll",
                    "contentType": "application/json"
                }
            ]
        }
    }
}
```
</details>