### PR TITLE
fix: convertion from td to tm wasn't adjusted to new sharing mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "editdor",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"private": true,
 	"homepage": "https://eclipse.github.io/editdor/",
 	"dependencies": {

--- a/src/components/Dialogs/ConvertTmDialog.jsx
+++ b/src/components/Dialogs/ConvertTmDialog.jsx
@@ -13,8 +13,8 @@
 import React, { forwardRef, useContext, useEffect, useImperativeHandle } from 'react';
 import ReactDOM from "react-dom";
 import ediTDorContext from "../../context/ediTDorContext";
+import { prepareTdForSharing } from '../../share';
 import { DialogTemplate } from "./DialogTemplate";
-import { compress } from "../../external/TdPlayground"
 
 export const ConvertTmDialog = forwardRef((props, ref) => {
     const context = useContext(ediTDorContext);
@@ -228,6 +228,7 @@ const convertTmToTd = (td, htmlInputs) => {
     delete parse["@type"];
     delete parse["tm:required"];
 
-    let permalink = `${window.location.origin + window.location.pathname}?td=${compress(JSON.stringify(parse))}`;
+    const compressedTd = prepareTdForSharing(JSON.stringify(parse));
+    let permalink = `${window.location.origin + window.location.pathname}?td=${compressedTd}`;
     window.open(permalink, "_blank");
 }


### PR DESCRIPTION
When converting a TM to a TD the newly opened tab wasn't able to correctly parse the generated TD as it was not using the new sharing mechanism with lz-string.