### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Eclipse EdiTDor
+
+Any contribution to this project is welcome.
+If you want to report a bug or question, please check the [issue list](https://github.com/eclipse/editdor/issues) or create a new issue.
+If you want to contribute to this project by coding, please fork the repository and then follow the general contribution guidelines described [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).
+However, EdiTDor is an [Eclipse IoT](https://iot.eclipse.org) project and as such is governed by the Eclipse Development process.
+This process helps us in creating great open source software within a safe legal framework.
+
+Thus, before your contribution can be accepted by the project team, contributors must electronically sign the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php) and follow these preliminary steps:
+
+-   Obtain an [Eclipse Foundation account](https://accounts.eclipse.org/)
+    -   Anyone who currently uses Eclipse Bugzilla or Gerrit systems already has one of those
+    -   Newcomers can [create a new account](https://accounts.eclipse.org/user/register?destination=user)
+-   Add your GiHub username to your Eclipse Foundation account
+    -   ([Log into Eclipse](https://accounts.eclipse.org/))
+    -   Go to the _Edit Profile_ tab
+    -   Fill in the _GitHub ID_ under _Social Media Links_ and save
+-   Sign the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php)
+    -   ([Log into Eclipse](https://accounts.eclipse.org/))
+    -   If the _Status_ entry _Eclipse Contributor Agreement_ has a green checkmark, the ECA is already signed
+    -   If not, go to the _Eclipse Contributor Agreement_ tab or follow the corresponding link under _Status_
+    -   Fill out the form and sign it electronically
+-   Sign-off every commit using the same email address used for your Eclipse account
+    -   Set the Git user email address with `git config user.email "<your Eclipse account email>"`
+    -   Add the `-s` flag when you make the commit(s), e.g. `git commit -s -m "feat: add support for magic"`
+-   Open a [Pull Request](https://github.com/eclipse/editdor/pulls)
+
+For more information, please see the Eclipse Committer Handbook:
+https://www.eclipse.org/projects/handbook/#resources-commit

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The goal of this project is the easy creation of W3C Thing Description instances
 - TailwindCSS
 
 ## Contribution guide
-Any contribution to this project is welcome. If you want to report a bug or question, please check the [issue list](https://github.com/eclipse/editdor/issues) or create a new issue. If you want to contribute to this project by coding, please follow the general contribution guidelines described [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md). Note that you need to have an Eclipse account to make Pull Requests.
+Please follow our [contribution guide](./CONTRIBUTING.md).
 
 ## License
 * [Eclipse Public License v. 2.0](http://www.eclipse.org/legal/epl-2.0)


### PR DESCRIPTION
I have copied over the text from node-wot at https://github.com/eclipse-thingweb/node-wot/blob/master/CONTRIBUTING.md and merged with the contribution guideline we have here. Without this, #100 can happen and will not be easy to revert and a new PR is needed.