### PR TITLE
Docs update copyright

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/App/AppFooter.jsx
+++ b/src/components/App/AppFooter.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/App/AppFooter.jsx
+++ b/src/components/App/AppFooter.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/App/AppHeader.jsx
+++ b/src/components/App/AppHeader.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/App/AppHeader.jsx
+++ b/src/components/App/AppHeader.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddActionDialog.jsx
+++ b/src/components/Dialogs/AddActionDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddActionDialog.jsx
+++ b/src/components/Dialogs/AddActionDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddEventDialog.jsx
+++ b/src/components/Dialogs/AddEventDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddEventDialog.jsx
+++ b/src/components/Dialogs/AddEventDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddFormDialog.jsx
+++ b/src/components/Dialogs/AddFormDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddFormDialog.jsx
+++ b/src/components/Dialogs/AddFormDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddLinkTdDialog.jsx
+++ b/src/components/Dialogs/AddLinkTdDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddLinkTdDialog.jsx
+++ b/src/components/Dialogs/AddLinkTdDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddPropertyDialog.jsx
+++ b/src/components/Dialogs/AddPropertyDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/AddPropertyDialog.jsx
+++ b/src/components/Dialogs/AddPropertyDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/ConvertTmDialog.jsx
+++ b/src/components/Dialogs/ConvertTmDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/ConvertTmDialog.jsx
+++ b/src/components/Dialogs/ConvertTmDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/CreateTdDialog.jsx
+++ b/src/components/Dialogs/CreateTdDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/CreateTdDialog.jsx
+++ b/src/components/Dialogs/CreateTdDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/DialogComponents.jsx
+++ b/src/components/Dialogs/DialogComponents.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/DialogComponents.jsx
+++ b/src/components/Dialogs/DialogComponents.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/DialogTemplate.jsx
+++ b/src/components/Dialogs/DialogTemplate.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/DialogTemplate.jsx
+++ b/src/components/Dialogs/DialogTemplate.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/SettingsDialog.jsx
+++ b/src/components/Dialogs/SettingsDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/SettingsDialog.jsx
+++ b/src/components/Dialogs/SettingsDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/SettingsDialog.jsx
+++ b/src/components/Dialogs/SettingsDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/ShareDialog.jsx
+++ b/src/components/Dialogs/ShareDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/ShareDialog.jsx
+++ b/src/components/Dialogs/ShareDialog.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/SpinnerTemplate.jsx
+++ b/src/components/Dialogs/SpinnerTemplate.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Dialogs/SpinnerTemplate.jsx
+++ b/src/components/Dialogs/SpinnerTemplate.jsx
@@ -1,23 +1,40 @@
-import React from "react";
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import React from 'react';
 import ReactDOM from "react-dom";
 
-export const SpinnerTemplate = (_) => {
-  return ReactDOM.createPortal(
-    <div className="bg-transparent-400 absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center text-white">
-      <div className="bg-transparent-400 flex max-h-screen w-1/3 flex-col items-center justify-center p-4">
-        <div className="justify-center overflow-hidden p-2">
-          {showSpinner()}
-        </div>
-      </div>
-    </div>,
-    document.getElementById("modal-root")
-  );
+export const SpinnerTemplate = _ => {
+
+    return ReactDOM.createPortal(
+        <div
+            className="flex bg-transparent-400 w-full h-full absolute top-0 left-0 justify-center items-center z-10 text-white">
+            <div className="bg-transparent-400 w-1/3 flex flex-col justify-center items-center p-4 max-h-screen">
+
+                <div className="justify-center overflow-hidden p-2">
+                    {showSpinner()}
+                </div>
+
+            </div>
+        </div>,
+        document.getElementById("modal-root")
+    );
+
 };
 
-const showSpinner = (_) => {
-  return (
-    <div className="spinner-container">
-      <div className="loading-spinner"></div>
-    </div>
-  );
-};
+const showSpinner = _ => {
+    return (<div className="spinner-container">
+        <div className="loading-spinner">
+        </div>
+    </div>);
+}

--- a/src/components/Dialogs/SpinnerTemplate.jsx
+++ b/src/components/Dialogs/SpinnerTemplate.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,30 +11,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import React from 'react';
+import React from "react";
 import ReactDOM from "react-dom";
 
-export const SpinnerTemplate = _ => {
-
-    return ReactDOM.createPortal(
-        <div
-            className="flex bg-transparent-400 w-full h-full absolute top-0 left-0 justify-center items-center z-10 text-white">
-            <div className="bg-transparent-400 w-1/3 flex flex-col justify-center items-center p-4 max-h-screen">
-
-                <div className="justify-center overflow-hidden p-2">
-                    {showSpinner()}
-                </div>
-
-            </div>
-        </div>,
-        document.getElementById("modal-root")
-    );
-
+export const SpinnerTemplate = (_) => {
+  return ReactDOM.createPortal(
+    <div className="bg-transparent-400 absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center text-white">
+      <div className="bg-transparent-400 flex max-h-screen w-1/3 flex-col items-center justify-center p-4">
+        <div className="justify-center overflow-hidden p-2">
+          {showSpinner()}
+        </div>
+      </div>
+    </div>,
+    document.getElementById("modal-root")
+  );
 };
 
-const showSpinner = _ => {
-    return (<div className="spinner-container">
-        <div className="loading-spinner">
-        </div>
-    </div>);
-}
+const showSpinner = (_) => {
+  return (
+    <div className="spinner-container">
+      <div className="loading-spinner"></div>
+    </div>
+  );
+};

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/InfoIcon/InfoIcon.jsx
+++ b/src/components/InfoIcon/InfoIcon.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/InfoIcon/InfoIcon.jsx
+++ b/src/components/InfoIcon/InfoIcon.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/InfoIcon/InfoTooltips.jsx
+++ b/src/components/InfoIcon/InfoTooltips.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/InfoIcon/InfoTooltips.jsx
+++ b/src/components/InfoIcon/InfoTooltips.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/TDViewer.jsx
+++ b/src/components/TDViewer/TDViewer.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/TDViewer.jsx
+++ b/src/components/TDViewer/TDViewer.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Action.jsx
+++ b/src/components/TDViewer/components/Action.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Action.jsx
+++ b/src/components/TDViewer/components/Action.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Event.jsx
+++ b/src/components/TDViewer/components/Event.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Event.jsx
+++ b/src/components/TDViewer/components/Event.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Form.jsx
+++ b/src/components/TDViewer/components/Form.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -197,7 +197,7 @@ async function writeProperty(td, propertyName, content) {
 
     return {
       result: `Successfully wrote ${
-         JSON.stringify(contentConverted).length > 50
+        JSON.stringify(contentConverted).length > 50
           ? JSON.stringify(contentConverted).slice(0, 50) + "..."
           : JSON.stringify(contentConverted)
       } to '${propertyName}'.`,

--- a/src/components/TDViewer/components/Form.jsx
+++ b/src/components/TDViewer/components/Form.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/InteractionSection.jsx
+++ b/src/components/TDViewer/components/InteractionSection.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import React, { useContext, useState } from 'react';
-import ediTDorContext from '../../../context/ediTDorContext';
-import { AddActionDialog } from '../../Dialogs/AddActionDialog';
-import { AddEventDialog } from '../../Dialogs/AddEventDialog';
-import { AddPropertyDialog } from '../../Dialogs/AddPropertyDialog';
-import { InfoIconWrapper } from '../../InfoIcon/InfoIcon';
-import { tooltipMapper } from '../../InfoIcon/InfoTooltips';
-import Action from './Action';
-import Event from './Event';
-import Property from './Property';
-import { SearchBar } from './SearchBar';
+import React, { useContext, useState } from "react";
+import ediTDorContext from "../../../context/ediTDorContext";
+import { AddActionDialog } from "../../Dialogs/AddActionDialog";
+import { AddEventDialog } from "../../Dialogs/AddEventDialog";
+import { AddPropertyDialog } from "../../Dialogs/AddPropertyDialog";
+import { InfoIconWrapper } from "../../InfoIcon/InfoIcon";
+import { tooltipMapper } from "../../InfoIcon/InfoTooltips";
+import Action from "./Action";
+import Event from "./Event";
+import Property from "./Property";
+import { SearchBar } from "./SearchBar";
 
 const SORT_ASC = "asc";
 const SORT_DESC = "desc";

--- a/src/components/TDViewer/components/InteractionSection.jsx
+++ b/src/components/TDViewer/components/InteractionSection.jsx
@@ -1,14 +1,27 @@
-import React, { useContext, useState } from "react";
-import ediTDorContext from "../../../context/ediTDorContext";
-import { AddActionDialog } from "../../Dialogs/AddActionDialog";
-import { AddEventDialog } from "../../Dialogs/AddEventDialog";
-import { AddPropertyDialog } from "../../Dialogs/AddPropertyDialog";
-import { InfoIconWrapper } from "../../InfoIcon/InfoIcon";
-import { tooltipMapper } from "../../InfoIcon/InfoTooltips";
-import Action from "./Action";
-import Event from "./Event";
-import Property from "./Property";
-import { SearchBar } from "./SearchBar";
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import React, { useContext, useState } from 'react';
+import ediTDorContext from '../../../context/ediTDorContext';
+import { AddActionDialog } from '../../Dialogs/AddActionDialog';
+import { AddEventDialog } from '../../Dialogs/AddEventDialog';
+import { AddPropertyDialog } from '../../Dialogs/AddPropertyDialog';
+import { InfoIconWrapper } from '../../InfoIcon/InfoIcon';
+import { tooltipMapper } from '../../InfoIcon/InfoTooltips';
+import Action from './Action';
+import Event from './Event';
+import Property from './Property';
+import { SearchBar } from './SearchBar';
 
 const SORT_ASC = "asc";
 const SORT_DESC = "desc";

--- a/src/components/TDViewer/components/Link.jsx
+++ b/src/components/TDViewer/components/Link.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Link.jsx
+++ b/src/components/TDViewer/components/Link.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/LinkSection.jsx
+++ b/src/components/TDViewer/components/LinkSection.jsx
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 import * as joint from "jointjs";
 import { useContext, useEffect, useRef, useState } from "react";
 import ediTDorContext from "../../../context/ediTDorContext";

--- a/src/components/TDViewer/components/LinkSection.jsx
+++ b/src/components/TDViewer/components/LinkSection.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Property.jsx
+++ b/src/components/TDViewer/components/Property.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/Property.jsx
+++ b/src/components/TDViewer/components/Property.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/RenderedObject.jsx
+++ b/src/components/TDViewer/components/RenderedObject.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/RenderedObject.jsx
+++ b/src/components/TDViewer/components/RenderedObject.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/SearchBar.jsx
+++ b/src/components/TDViewer/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/SearchBar.jsx
+++ b/src/components/TDViewer/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/ValidationSection.jsx
+++ b/src/components/TDViewer/components/ValidationSection.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/TDViewer/components/ValidationSection.jsx
+++ b/src/components/TDViewer/components/ValidationSection.jsx
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 import { useContext, useEffect, useState } from "react";
 import ediTDorContext from "../../../context/ediTDorContext";
 import { ImCheckmark, ImCross } from "react-icons/im";

--- a/src/context/GlobalState.jsx
+++ b/src/context/GlobalState.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/context/GlobalState.jsx
+++ b/src/context/GlobalState.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/context/ediTDorContext.js
+++ b/src/context/ediTDorContext.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/context/ediTDorContext.js
+++ b/src/context/ediTDorContext.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/context/editorReducers.js
+++ b/src/context/editorReducers.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/context/editorReducers.js
+++ b/src/context/editorReducers.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/external/TdPlayground.js
+++ b/src/external/TdPlayground.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import jsonld from 'jsonld';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';

--- a/src/external/TdPlayground.js
+++ b/src/external/TdPlayground.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/external/shared.js
+++ b/src/external/shared.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/ 
  /**
   * This file contains functions, which are required by the core package as
   * well as by the assertions package

--- a/src/external/shared.js
+++ b/src/external/shared.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {

--- a/src/services/fileTdService.js
+++ b/src/services/fileTdService.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 /**
  * Check if the Browser Supports the new Native File System Api (Chromium 86.0)
  */

--- a/src/services/fileTdService.js
+++ b/src/services/fileTdService.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/services/targetUrl.ts
+++ b/src/services/targetUrl.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/services/targetUrl.ts
+++ b/src/services/targetUrl.ts
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 const TARGET_URL_KEY: string = "target-url";
 
 /**

--- a/src/services/targetUrl.ts
+++ b/src/services/targetUrl.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/services/thingsApiService.ts
+++ b/src/services/thingsApiService.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/services/thingsApiService.ts
+++ b/src/services/thingsApiService.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/services/thingsApiService.ts
+++ b/src/services/thingsApiService.ts
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
 interface ThingDescription {
   id: string;
   [key: string]: any;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/share.js
+++ b/src/share.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { compress, decompress } from "./external/TdPlayground";
 import { isThingModel } from "./util";
 

--- a/src/share.js
+++ b/src/share.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2020 Contributors to the Eclipse Foundation
- *
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
  *

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
- * 
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
  *

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 type CsvData = {
   name: string;
   title?: string;

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/workers/schemaWorker.js
+++ b/src/workers/schemaWorker.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import {
   extractSchemaUrisFromContext,
   extractSchemaUriFromBase,

--- a/src/workers/schemaWorker.js
+++ b/src/workers/schemaWorker.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/workers/validationWorker.js
+++ b/src/workers/validationWorker.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { tdValidator, tmValidator } from "../external/TdPlayground";
 import { isThingModel } from "../util";
 

--- a/src/workers/validationWorker.js
+++ b/src/workers/validationWorker.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/workers/workerFunctions.js
+++ b/src/workers/workerFunctions.js
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 // Caches the fetched schemas and is used for future requests to the same schema address.
 let schemaCache = new Map();
 

--- a/src/workers/workerFunctions.js
+++ b/src/workers/workerFunctions.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 - 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.


### PR DESCRIPTION
This MR has the copyright final year updated in all files with the extension .jsx, js and .ts. For the files that didn't have the copyright it has added with the year 2018-2015 to maintain the consistency across all files. 