### PR TITLE
Feat button to test all preview values

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "react-feather": "^2.0.10",
     "react-icons": "^5.2.1",
     "react-scan": "^0.4.3",
-    "react-step-progress-bar": "^1.0.3",
     "react-tooltip": "^5.26.4",
+    "tailwind-merge": "^3.3.1",
     "wot-thing-description-types": "1.1.0-12-March-2025",
     "wot-typescript-definitions": "^0.8.0-SNAPSHOT.30"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-feather": "^2.0.10",
     "react-icons": "^5.2.1",
     "react-scan": "^0.4.3",
+    "react-step-progress-bar": "^1.0.3",
     "react-tooltip": "^5.26.4",
     "wot-thing-description-types": "1.1.0-12-March-2025",
     "wot-typescript-definitions": "^0.8.0-SNAPSHOT.30"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "json-dup-key-validator": "^1.0.3",
     "jsonld": "^8.3.2",
     "jsonpointer": "^5.0.1",
+    "lodash": "^4.17.21",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.52.2",
     "react": "^18.2.0",
@@ -45,6 +46,7 @@
     "react-scan": "^0.4.3",
     "react-tooltip": "^5.26.4",
     "tailwind-merge": "^3.3.1",
+    "uuid": "^13.0.0",
     "wot-thing-description-types": "1.1.0-12-March-2025",
     "wot-typescript-definitions": "^0.8.0-SNAPSHOT.30"
   },
@@ -56,6 +58,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/babel__core": "^7",
     "@types/jsonpointer": "^4.0.2",
+    "@types/lodash": "^4",
     "@types/node": "^22.13.15",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -35,7 +35,11 @@ interface SettingsProps {
 }
 
 const Settings: React.FC<SettingsProps> = ({
-  initialData = { northboundUrl: "", southboundUrl: "", pathToValue: "/" },
+  initialData = {
+    northboundUrl: "",
+    southboundUrl: "",
+    pathToValue: "/",
+  },
   onChange,
   hideTitle = false,
   className = "",

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -1,0 +1,235 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React, { useState, useEffect, useCallback } from "react";
+import InfoIconWrapper from "../InfoIcon/InfoIconWrapper";
+import DialogTextField from "../Dialogs/base/DialogTextField";
+import { isValidUrl } from "../../utils/strings";
+
+export interface SettingsData {
+  northboundUrl: string;
+  southboundUrl: string;
+  pathToValue: string;
+}
+
+export interface SettingsErrors {
+  northboundUrl: string;
+  southboundUrl: string;
+  pathToValue: string;
+}
+
+interface SettingsProps {
+  initialData?: SettingsData;
+  onChange?: (data: SettingsData, isValid: boolean) => void;
+  hideTitle?: boolean;
+  className?: string;
+}
+
+const Settings: React.FC<SettingsProps> = ({
+  initialData = { northboundUrl: "", southboundUrl: "", pathToValue: "/" },
+  onChange,
+  hideTitle = false,
+  className = "",
+}) => {
+  const [data, setData] = useState<SettingsData>(initialData);
+  const [errors, setErrors] = useState<SettingsErrors>({
+    northboundUrl: "",
+    southboundUrl: "",
+    pathToValue: "",
+  });
+
+  useEffect(() => {
+    setData(initialData);
+  }, [initialData]);
+
+  useEffect(() => {
+    if (onChange) {
+      const isValid =
+        !errors.northboundUrl && !errors.southboundUrl && !errors.pathToValue;
+      onChange(data, isValid);
+    }
+  }, [data, errors, onChange]);
+
+  const handleNorthboundUrlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setData((prev) => ({ ...prev, northboundUrl: value }));
+
+      if (value === "") {
+        setErrors((prev) => ({ ...prev, northboundUrl: "" }));
+      } else if (!isValidUrl(value)) {
+        setErrors((prev) => ({
+          ...prev,
+          northboundUrl:
+            "Please enter a valid URL (e.g., http://localhost:8080)",
+        }));
+      } else {
+        setErrors((prev) => ({ ...prev, northboundUrl: "" }));
+      }
+    },
+    []
+  );
+
+  const handleSouthboundUrlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setData((prev) => ({ ...prev, southboundUrl: value }));
+
+      if (value === "") {
+        setErrors((prev) => ({ ...prev, southboundUrl: "" }));
+      } else if (!isValidUrl(value)) {
+        setErrors((prev) => ({
+          ...prev,
+          southboundUrl:
+            "Please enter a valid URL (e.g., http://localhost:8080)",
+        }));
+      } else {
+        setErrors((prev) => ({ ...prev, southboundUrl: "" }));
+      }
+    },
+    []
+  );
+
+  const handlePathToValueChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setData((prev) => ({ ...prev, pathToValue: value }));
+
+      if (value === "") {
+        setErrors((prev) => ({ ...prev, pathToValue: "" }));
+      } else if (!value.startsWith("/")) {
+        setErrors((prev) => ({
+          ...prev,
+          pathToValue: "Path must start with '/'",
+        }));
+      } else if (value.includes(" ")) {
+        setErrors((prev) => ({
+          ...prev,
+          pathToValue: "Path cannot contain spaces",
+        }));
+      } else {
+        setErrors((prev) => ({ ...prev, pathToValue: "" }));
+      }
+    },
+    []
+  );
+
+  return (
+    <div className={className}>
+      <div className="rounded-md bg-black bg-opacity-80 p-2">
+        {!hideTitle && (
+          <h1 className="font-bold">Third Party Service Configuration</h1>
+        )}
+        <div className="px-4">
+          <h2 className="py-2 text-justify text-gray-400">
+            If you want to interact with non-HTTP devices via a gateway, you can
+            send it TDs to its southbound endpoint with a "POST" request.
+            Similarly, you can retrieve TDs from its northbound endpoint. The id
+            of the initial TD is used to correlate both.
+          </h2>
+
+          <DialogTextField
+            label={
+              <InfoIconWrapper
+                tooltip={{
+                  html: "The target northbound URL should point to a server that implements the Discovery Specifications's Things API. If a valid target URL is provided, the editTDor will use it for all interactions with the Thing.",
+                  href: "",
+                }}
+                id="settings-target-url-northbound-info"
+                children={"Target URL Northbound:"}
+              />
+            }
+            placeholder="e.g.: http://localhost:8080/"
+            id="settings-target-url-field-northbound"
+            type="text"
+            value={data.northboundUrl}
+            autoFocus={false}
+            onChange={handleNorthboundUrlChange}
+            className={`${
+              errors.northboundUrl ? "border-red-500" : "border-gray-600"
+            } w-full rounded-md border-2 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm`}
+          />
+          {errors.northboundUrl && (
+            <div className="mt-1 text-sm text-red-500">
+              {errors.northboundUrl}
+            </div>
+          )}
+
+          <DialogTextField
+            label={
+              <InfoIconWrapper
+                tooltip={{
+                  html: "The target southbound URL",
+                  href: "",
+                }}
+                id="settings-target-url-southbound-info"
+                children={"Target URL Southbound:"}
+              />
+            }
+            placeholder="e.g.: http://localhost:8080/"
+            id="settings-target-url-field-southbound"
+            type="text"
+            value={data.southboundUrl}
+            autoFocus={false}
+            onChange={handleSouthboundUrlChange}
+            className={`${
+              errors.southboundUrl ? "border-red-500" : "border-gray-600"
+            } w-full rounded-md border-2 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm`}
+          />
+          {errors.southboundUrl && (
+            <div className="mt-1 text-sm text-red-500">
+              {errors.southboundUrl}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="my-4 rounded-md bg-black bg-opacity-80 p-2">
+        {!hideTitle && <h1 className="font-bold">Path to value</h1>}
+        <div className="px-4">
+          <h2 className="py-2 text-justify text-gray-400">
+            {`If the gateway is wrapping the payloads in a JSON object, please provide the path to the value as a JSON pointer. For a JSON like {"foo": {"bar":"baz"}}, where baz is the value according the Data Schema of the TD, you should enter /foo/bar.`}
+          </h2>
+
+          <DialogTextField
+            label={
+              <InfoIconWrapper
+                tooltip={{
+                  html: "JSON pointer path to the actual value in wrapped payloads. Use forward slashes to navigate nested objects.",
+                  href: "",
+                }}
+                id="settingsPathToValueInfo"
+                children={"JSON Pointer Path:"}
+              />
+            }
+            placeholder="/foo/bar"
+            id="settingsPathToValueField"
+            type="text"
+            value={data.pathToValue}
+            autoFocus={false}
+            onChange={handlePathToValueChange}
+            className={`${
+              errors.pathToValue ? "border-red-500" : "border-gray-600"
+            } w-full rounded-md border-2 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm`}
+          />
+          {errors.pathToValue && (
+            <div className="mt-1 text-sm text-red-500">
+              {errors.pathToValue}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/src/components/App/TmInputForm.tsx
+++ b/src/components/App/TmInputForm.tsx
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React, { useState, useEffect } from "react";
+import { extractPlaceholders } from "../../services/operations";
+
+interface TmInputFormProps {
+  tmContent: string;
+  onValueUpdate: (values: Record<string, string>) => void;
+}
+
+const TmInputForm: React.FC<TmInputFormProps> = ({
+  tmContent,
+  onValueUpdate,
+}) => {
+  const [inputValues, setInputValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (tmContent) {
+      const placeholders = extractPlaceholders(tmContent);
+      const initialValues = placeholders.reduce((acc, key) => {
+        acc[key] = "";
+        return acc;
+      }, {});
+      setInputValues(initialValues);
+    }
+  }, [tmContent]);
+
+  useEffect(() => {
+    if (Object.keys(inputValues).length > 0) {
+      onValueUpdate(inputValues);
+    }
+  }, [inputValues, onValueUpdate]);
+
+  const handleInputChange = (placeholder: string, value: string) => {
+    setInputValues((prev) => {
+      const updated = { ...prev, [placeholder]: value };
+      return updated;
+    });
+  };
+
+  return (
+    <div className="placeholder-inputs-container w-full">
+      {Object.keys(inputValues).map((placeholder) => (
+        <div key={placeholder} className="py-1">
+          <label
+            htmlFor={`tm-input-${placeholder}`}
+            className="pl-2 text-sm font-medium text-gray-400"
+          >
+            {placeholder}:
+          </label>
+          <input
+            id={`tm-input-${placeholder}`}
+            type="text"
+            name={placeholder}
+            value={inputValues[placeholder]}
+            onChange={(e) => handleInputChange(placeholder, e.target.value)}
+            className="w-full rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-white outline-none hover:border-blue-500 focus:border-blue-500 sm:text-sm"
+            placeholder="Enter a value..."
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TmInputForm;

--- a/src/components/App/TmInputForm.tsx
+++ b/src/components/App/TmInputForm.tsx
@@ -10,42 +10,33 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useState, useEffect } from "react";
-import { extractPlaceholders } from "../../services/operations";
+import React, { useEffect, useState } from "react";
 
 interface TmInputFormProps {
-  tmContent: string;
-  onValueUpdate: (values: Record<string, string>) => void;
+  inputValues: Record<string, string>;
+  onValueChange: (placeholder: string, value: string) => void;
 }
 
 const TmInputForm: React.FC<TmInputFormProps> = ({
-  tmContent,
-  onValueUpdate,
+  inputValues,
+  onValueChange,
 }) => {
-  const [inputValues, setInputValues] = useState<Record<string, string>>({});
+  const [localValues, setLocalValues] =
+    useState<Record<string, string>>(inputValues);
 
   useEffect(() => {
-    if (tmContent) {
-      const placeholders = extractPlaceholders(tmContent);
-      const initialValues = placeholders.reduce((acc, key) => {
-        acc[key] = "";
-        return acc;
-      }, {});
-      setInputValues(initialValues);
-    }
-  }, [tmContent]);
+    setLocalValues(inputValues);
+  }, [inputValues]);
 
-  useEffect(() => {
-    if (Object.keys(inputValues).length > 0) {
-      onValueUpdate(inputValues);
-    }
-  }, [inputValues, onValueUpdate]);
+  const handleChange = (placeholder: string, value: string) => {
+    setLocalValues((prev) => ({
+      ...prev,
+      [placeholder]: value,
+    }));
+  };
 
-  const handleInputChange = (placeholder: string, value: string) => {
-    setInputValues((prev) => {
-      const updated = { ...prev, [placeholder]: value };
-      return updated;
-    });
+  const handleBlur = (placeholder: string, value: string) => {
+    onValueChange(placeholder, value);
   };
 
   return (
@@ -62,8 +53,9 @@ const TmInputForm: React.FC<TmInputFormProps> = ({
             id={`tm-input-${placeholder}`}
             type="text"
             name={placeholder}
-            value={inputValues[placeholder]}
-            onChange={(e) => handleInputChange(placeholder, e.target.value)}
+            value={localValues[placeholder] || ""}
+            onChange={(e) => handleChange(placeholder, e.target.value)}
+            onBlur={(e) => handleBlur(placeholder, e.target.value)}
             className="w-full rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-white outline-none hover:border-blue-500 focus:border-blue-500 sm:text-sm"
             placeholder="Enter a value..."
           />

--- a/src/components/Dialogs/AddActionDialog.tsx
+++ b/src/components/Dialogs/AddActionDialog.tsx
@@ -126,11 +126,11 @@ const AddActionDialog = forwardRef<AddActionDialogRef>((_, ref) => {
   if (display) {
     return ReactDOM.createPortal(
       <DialogTemplate
-        onCancel={close}
-        onSubmit={() => {
+        onHandleEventLeftButton={close}
+        onHandleEventRightButton={() => {
           onAddAction();
         }}
-        submitText={`Add ${name}`}
+        rightButton={`Add ${name}`}
         children={children}
         title={`Add New ${name}`}
         description={`Tell us a little something about the ${name} you want to add.`}

--- a/src/components/Dialogs/AddEventDialog.tsx
+++ b/src/components/Dialogs/AddEventDialog.tsx
@@ -127,11 +127,11 @@ const AddEventDialog = forwardRef<AddEventDialogRef>((_, ref) => {
   if (display) {
     return ReactDOM.createPortal(
       <DialogTemplate
-        onCancel={close}
-        onSubmit={() => {
+        onHandleEventLeftButton={close}
+        onHandleEventRightButton={() => {
           onAddEvent();
         }}
-        submitText={`Add ${name}`}
+        rightButton={`Add ${name}`}
         children={children}
         title={`Add New ${name}`}
         description={`Tell us a little something about the ${name} you want to add.`}

--- a/src/components/Dialogs/AddFormDialog.tsx
+++ b/src/components/Dialogs/AddFormDialog.tsx
@@ -112,8 +112,8 @@ const AddFormDialog = forwardRef<AddFormDialogRef, AddFormDialogProps>(
     if (display) {
       return ReactDOM.createPortal(
         <DialogTemplate
-          onCancel={close}
-          onSubmit={() => {
+          onHandleEventLeftButton={close}
+          onHandleEventRightButton={() => {
             const form: Form = {
               op: operations(type)
                 .map((x) => {
@@ -140,7 +140,7 @@ const AddFormDialog = forwardRef<AddFormDialogRef, AddFormDialogProps>(
               close();
             }
           }}
-          submitText={"Add"}
+          rightButton={"Add"}
           children={children}
           title={`Add ${name} Form`}
           description={`Tell us how this ${name} can be interfaced by selecting operations below and providing an href.`}

--- a/src/components/Dialogs/AddLinkTdDialog.tsx
+++ b/src/components/Dialogs/AddLinkTdDialog.tsx
@@ -309,9 +309,9 @@ const AddLinkTdDialog = forwardRef<AddLinkTdDialogRef, AddLinkTdDialogProps>(
     if (display) {
       return ReactDOM.createPortal(
         <DialogTemplate
-          onCancel={close}
-          onSubmit={handleAddLink}
-          submitText={"Add"}
+          onHandleEventLeftButton={close}
+          onHandleEventRightButton={handleAddLink}
+          rightButton={"Add"}
           children={children}
           title={`Add Link `}
           description={`Tell us how this ${tdJSON.title} can interact with other ressources`}

--- a/src/components/Dialogs/AddPropertyDialog.tsx
+++ b/src/components/Dialogs/AddPropertyDialog.tsx
@@ -183,11 +183,11 @@ export const AddPropertyDialog = forwardRef<AddPropertyDialogRef, {}>(
     if (display) {
       return ReactDOM.createPortal(
         <DialogTemplate
-          onCancel={close}
-          onSubmit={() => {
+          onHandleEventLeftButton={close}
+          onHandleEventRightButton={() => {
             onAddProperty();
           }}
-          submitText={`Add ${name}`}
+          rightButton={`Add ${name}`}
           children={children}
           title={`Add New ${name}`}
           description={`Tell us a little something about the ${name} you want to add.`}

--- a/src/components/Dialogs/ContributeToCatalog.tsx
+++ b/src/components/Dialogs/ContributeToCatalog.tsx
@@ -607,6 +607,8 @@ const ContributeToCatalog = forwardRef((props, ref) => {
         hasSubmit={true}
         leftButton={workflowState > 1 ? "Previous" : "Close"}
         rightButton={workflowState < 3 ? "Next" : "Close"}
+        auxiliaryButton={workflowState === 2}
+        onHandleEventAuxiliaryButton={close}
         title={"Contribute your TM to a TM Catalog"}
         description={
           "Fullfil the form below to contribute your TM to the Catalog specified in the endpoint at the end."

--- a/src/components/Dialogs/ContributeToCatalog.tsx
+++ b/src/components/Dialogs/ContributeToCatalog.tsx
@@ -36,7 +36,6 @@ import FormSubmission from "./base/FormSubmission";
 import FormInteraction from "./base/FormInteraction";
 import { isValidUrl, formatText } from "../../utils/strings";
 import { requestWeb } from "../../services/thingsApiService";
-
 import {
   normalizeContext,
   extractPlaceholders,
@@ -47,6 +46,7 @@ export interface IContributeToCatalogProps {
   openModal: () => void;
   close: () => void;
 }
+
 const TITLE = "Contribute your TM to a TM Catalog";
 const validationTmcMandatory =
   "https://raw.githubusercontent.com/wot-oss/tmc/main/internal/commands/validate/tmc-mandatory.schema.json";
@@ -157,7 +157,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
     setLicense("");
     setCopyrightYear("");
     setHolder("");
-    setErrorMessage("");
+    setErrorMetadata("");
     setCopied(false);
 
     setLink("");
@@ -192,7 +192,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
   const [license, setLicense] = useState<string>("");
   const [copyrightYear, setCopyrightYear] = useState<string>("");
   const [holder, setHolder] = useState<string>("");
-  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [errorMetadata, setErrorMetadata] = useState<string>("");
   const [copied, setCopied] = useState<boolean>(false);
 
   const [tmGeneratedToSend, setTmGeneratedToSend] =
@@ -200,7 +200,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
 
   const handleCatalogValidation = async () => {
     console.log("started validation");
-    setErrorMessage("");
+    setErrorMetadata("");
     setIsValid(false);
     setIsValidating(true);
 
@@ -223,7 +223,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
     if (model === "" || author === "" || manufacturer === "") {
       setIsValid(false);
       setIsValidating(false);
-      setErrorMessage(
+      setErrorMetadata(
         `Please fill in all required fields: ${model === "" ? "Model" : ""} ${author === "" ? "Author" : ""} ${manufacturer === "" ? "Manufacturer" : ""}`
       );
       return;
@@ -233,7 +233,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
       tdCopy["@context"] = normalizeContext(tdCopy["@context"]);
     } catch (err) {
       setIsValid(false);
-      setErrorMessage(
+      setErrorMetadata(
         err instanceof Error ? err.message : "Context normalization error"
       );
       return;
@@ -294,7 +294,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
       setErrorMessage("");
     } catch (err) {
       setIsValid(false);
-      setErrorMessage(
+      setErrorMetadata(
         "Could not validate: " +
           (err instanceof Error ? err.message : String(err))
       );
@@ -320,7 +320,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
     await navigator.clipboard.writeText(JSON.stringify(tdCopy, null, 2));
     setCopied(true);
   };
-  const handleOnChangeModel = (e) => {
+  const handleOnChangeModel = (e: any) => {
     setModel(e.target.value);
     contributeCatalogData.model = e.target.value;
     context.updateContributeCatalog(contributeCatalogData);
@@ -328,7 +328,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
     setSubmitted(false);
   };
 
-  const handleOnChangeAuthor = (e) => {
+  const handleOnChangeAuthor = (e: any) => {
     setAuthor(e.target.value);
     contributeCatalogData.author = e.target.value;
     context.updateContributeCatalog(contributeCatalogData);
@@ -336,7 +336,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
     setSubmitted(false);
   };
 
-  const handleOnChangeManufacturer = (e) => {
+  const handleOnChangeManufacturer = (e: any) => {
     setManufacturer(e.target.value);
     contributeCatalogData.manufacturer = e.target.value;
     context.updateContributeCatalog(contributeCatalogData);
@@ -344,19 +344,19 @@ const ContributeToCatalog = forwardRef((props, ref) => {
     setSubmitted(false);
   };
 
-  const handleOnChangeLicense = (e) => {
+  const handleOnChangeLicense = (e: any) => {
     setLicense(e.target.value);
     contributeCatalogData.license = e.target.value;
     context.updateContributeCatalog(contributeCatalogData);
   };
 
-  const handleOnChangeCopyrightYear = (e) => {
+  const handleOnChangeCopyrightYear = (e: any) => {
     setCopyrightYear(e.target.value);
     contributeCatalogData.copyrightYear = e.target.value;
     context.updateContributeCatalog(contributeCatalogData);
   };
 
-  const handleOnChangeHolder = (e) => {
+  const handleOnChangeHolder = (e: any) => {
     setHolder(e.target.value);
     contributeCatalogData.holder = e.target.value;
     context.updateContributeCatalog(contributeCatalogData);
@@ -381,7 +381,6 @@ const ContributeToCatalog = forwardRef((props, ref) => {
   const handleFieldChange = (placeholder: string, value: string) => {
     setPlaceholderValues((prev) => {
       const updated = { ...prev, [placeholder]: value };
-      console.log("New state:", updated);
       return updated;
     });
     context.updateContributeCatalog({
@@ -640,7 +639,7 @@ const ContributeToCatalog = forwardRef((props, ref) => {
                 onClickCopyThingModel={handleCopyThingModelClick}
                 isValidating={isValidating}
                 isValid={isValid}
-                errorMessage={errorMessage}
+                errorMessage={errorMetadata}
                 copied={copied}
               />
             </>

--- a/src/components/Dialogs/ContributeToCatalog.tsx
+++ b/src/components/Dialogs/ContributeToCatalog.tsx
@@ -24,10 +24,9 @@ import type {
   FormElementBase,
   ThingDescription,
 } from "wot-thing-description-types";
-import "react-step-progress-bar/styles.css";
 import Ajv2019 from "ajv/dist/2019";
 import addFormats from "ajv-formats";
-import { ProgressBar, Step } from "react-step-progress-bar";
+import { ProgressBar, Step } from "./base/ProgressBar";
 
 import ediTDorContext from "../../context/ediTDorContext";
 import DialogTemplate from "./DialogTemplate";
@@ -39,7 +38,6 @@ import { requestWeb } from "../../services/thingsApiService";
 import {
   normalizeContext,
   extractPlaceholders,
-  replacePlaceholders,
 } from "../../services/operations";
 
 export interface IContributeToCatalogProps {

--- a/src/components/Dialogs/ContributeToCatalog.tsx
+++ b/src/components/Dialogs/ContributeToCatalog.tsx
@@ -35,11 +35,8 @@ import FormSubmission from "./base/FormSubmission";
 import FormInteraction from "./base/FormInteraction";
 import { isValidUrl, formatText } from "../../utils/strings";
 import { requestWeb } from "../../services/thingsApiService";
-import { readPropertyWithServient } from "../../services/form";
-import { extractIndexFromId } from "../../utils/strings";
+
 import { normalizeContext } from "../../services/operations";
-import { getLocalStorage } from "../../services/localStorage";
-import { getErrorSummary } from "../../utils/arrays";
 
 export interface IContributeToCatalogProps {
   openModal: () => void;

--- a/src/components/Dialogs/ContributeToCatalog.tsx
+++ b/src/components/Dialogs/ContributeToCatalog.tsx
@@ -622,12 +622,6 @@ const ContributeToCatalog = forwardRef((props, ref) => {
             <FormInteraction
               filteredHeaders={filteredHeaders}
               filteredRows={filteredRows}
-              setPropertyResponseMap={(responseMap) =>
-                dispatch({
-                  type: "SET_INTERACTION_PROPERTY_RESPONSE_MAP",
-                  payload: responseMap,
-                })
-              }
               backgroundTdToSend={state.workflow.backgroundTdToSend}
               interaction={state.interaction}
               dispatch={dispatch}

--- a/src/components/Dialogs/ConvertTmDialog.tsx
+++ b/src/components/Dialogs/ConvertTmDialog.tsx
@@ -20,7 +20,10 @@ import React, {
 import ReactDOM from "react-dom";
 import ediTDorContext from "../../context/ediTDorContext";
 import DialogTemplate from "./DialogTemplate";
-import { processConversionTMtoTD } from "../../services/operations";
+import {
+  processConversionTMtoTD,
+  extractPlaceholders,
+} from "../../services/operations";
 import TmInputForm from "../App/TmInputForm";
 
 export interface ConvertTmDialogRef {
@@ -48,15 +51,28 @@ const ConvertTmDialog = forwardRef<ConvertTmDialogRef>((props, ref) => {
     setAffordanceElements(createAffordanceElements(context.offlineTD));
   }, [context.offlineTD]);
 
+  useEffect(() => {
+    if (td) {
+      const placeholders = extractPlaceholders(td);
+      const initialValues = placeholders.reduce((acc, key) => {
+        acc[key] = "";
+        return acc;
+      }, {});
+      setPlaceholderValues(initialValues);
+    }
+  }, [td]);
+
   useImperativeHandle(ref, () => ({
     openModal: () => setDisplay(true),
     close: () => setDisplay(false),
   }));
 
-  const handlePlaceholderUpdate = (values: Record<string, string>) => {
-    setPlaceholderValues(values);
+  const handleFieldChange = (placeholder: string, value: string) => {
+    setPlaceholderValues((prev) => ({
+      ...prev,
+      [placeholder]: value,
+    }));
   };
-
   const handleGenerateTd = () => {
     const selections = getSelectedAffordances(affordanceElements);
 
@@ -88,8 +104,8 @@ const ConvertTmDialog = forwardRef<ConvertTmDialogRef>((props, ref) => {
       >
         <>
           <TmInputForm
-            tmContent={context.offlineTD}
-            onValueUpdate={handlePlaceholderUpdate}
+            inputValues={placeholderValues}
+            onValueChange={handleFieldChange}
           />
 
           <h2 className="pb-2 pt-4 text-gray-400">

--- a/src/components/Dialogs/ConvertTmDialog.tsx
+++ b/src/components/Dialogs/ConvertTmDialog.tsx
@@ -54,9 +54,11 @@ const ConvertTmDialog = forwardRef<ConvertTmDialogRef>((props, ref) => {
   if (display) {
     return ReactDOM.createPortal(
       <DialogTemplate
-        onCancel={close}
-        onSubmit={() => convertTmToTd(context.offlineTD, htmlInputs)}
-        submitText={"Generate TD"}
+        onHandleEventLeftButton={close}
+        onHandleEventRightButton={() =>
+          convertTmToTd(context.offlineTD, htmlInputs)
+        }
+        rightButton={"Generate TD"}
         children={htmlInputs}
         title={"Generate TD From TM"}
         description={"Please provide values to switch the placeholders with."}

--- a/src/components/Dialogs/CreateTdDialog.tsx
+++ b/src/components/Dialogs/CreateTdDialog.tsx
@@ -125,8 +125,8 @@ const CreateTdDialog = forwardRef((props, ref) => {
   if (display) {
     return ReactDOM.createPortal(
       <DialogTemplate
-        onCancel={close}
-        onSubmit={() => {
+        onHandleEventLeftButton={close}
+        onHandleEventRightButton={() => {
           let td = createNewTD(type, properties);
           let linkedTd = {};
           linkedTd[td["title"]] = td;
@@ -136,7 +136,7 @@ const CreateTdDialog = forwardRef((props, ref) => {
           close();
         }}
         children={content}
-        submitText={type === "TD" ? "Create TD" : "Create TM"}
+        rightButton={type === "TD" ? "Create TD" : "Create TM"}
         title={"Create a New TD/TM"}
         description={
           "To quickly create a basis for your new Thing Description/Thing Model just fill out this little template and we'll get you going."

--- a/src/components/Dialogs/DialogTemplate.tsx
+++ b/src/components/Dialogs/DialogTemplate.tsx
@@ -23,6 +23,8 @@ interface DialogTemplateProps {
   onHandleEventRightButton?: () => void;
   hasSubmit?: boolean;
   className?: string;
+  auxiliaryButton?: boolean;
+  onHandleEventAuxiliaryButton?: () => void;
 }
 
 const DialogTemplate: React.FC<DialogTemplateProps> = (props) => {
@@ -36,6 +38,9 @@ const DialogTemplate: React.FC<DialogTemplateProps> = (props) => {
 
   const rightText = props.rightButton ?? "Submit";
   const onHandleEventRightButton = props.onHandleEventRightButton ?? (() => {});
+  const auxiliaryButton = props.auxiliaryButton ?? false;
+  const onHandleEventAuxiliaryButton =
+    props.onHandleEventAuxiliaryButton ?? (() => {});
   const hasSubmit = props.hasSubmit ?? true;
   const className = props.className ?? "lg:w-[40%]";
 
@@ -72,18 +77,30 @@ const DialogTemplate: React.FC<DialogTemplateProps> = (props) => {
                 onClick={() => onHandleEventLeftButton()}
                 variant="primary"
                 type="button"
-                className="mr-1"
+                className="ml-2"
               >
                 {leftText}
               </BaseButton>
             )}
+            {auxiliaryButton && (
+              <BaseButton
+                id="closeButton"
+                onClick={() => onHandleEventAuxiliaryButton()}
+                variant="primary"
+                type="button"
+                className="ml-2 flex"
+              >
+                Close
+              </BaseButton>
+            )}
+
             {hasSubmit && (
               <BaseButton
                 id="rightButton"
                 onClick={() => onHandleEventRightButton()}
                 variant="primary"
                 type="button"
-                className="flex"
+                className="ml-2 flex"
               >
                 {rightText}
               </BaseButton>

--- a/src/components/Dialogs/DialogTemplate.tsx
+++ b/src/components/Dialogs/DialogTemplate.tsx
@@ -17,10 +17,10 @@ interface DialogTemplateProps {
   title?: string;
   description?: string;
   children?: ReactNode;
-  cancelText?: string;
-  onCancel?: () => void;
-  submitText?: string;
-  onSubmit?: () => void;
+  leftButton?: string;
+  onHandleEventLeftButton?: () => void;
+  rightButton?: string;
+  onHandleEventRightButton?: () => void;
   hasSubmit?: boolean;
   className?: string;
 }
@@ -31,12 +31,13 @@ const DialogTemplate: React.FC<DialogTemplateProps> = (props) => {
     props.description ?? "Default description, please override.";
   const children = props.children ?? <></>;
 
-  const cancelText = props.cancelText ?? "Cancel";
-  const onCancel = props.onCancel ?? (() => {});
+  const leftText = props.leftButton ?? "Cancel";
+  const onHandleEventLeftButton = props.onHandleEventLeftButton ?? (() => {});
 
-  const submitText = props.submitText ?? "Submit";
-  const onSubmit = props.onSubmit ?? (() => {});
+  const rightText = props.rightButton ?? "Submit";
+  const onHandleEventRightButton = props.onHandleEventRightButton ?? (() => {});
   const hasSubmit = props.hasSubmit ?? true;
+  const className = props.className ?? "lg:w-[40%]";
 
   let keysDown = {};
   window.onkeydown = function (e: KeyboardEvent) {
@@ -55,35 +56,36 @@ const DialogTemplate: React.FC<DialogTemplateProps> = (props) => {
   return (
     <>
       <div className="absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center bg-black bg-opacity-80 text-white">
-        <div className="flex max-h-[95%] w-[80%] flex-col justify-start rounded-xl bg-gray-500 p-4 shadow-xl lg:w-[40%]">
+        <div
+          className={`flex max-h-[95%] w-[80%] flex-col justify-start rounded-xl bg-gray-500 p-4 shadow-xl ${className}`}
+        >
           <div className="flex flex-row items-center justify-start">
             <h1 className="flex-grow pl-2 text-2xl font-bold">{title}</h1>
           </div>
-          <h2 className={`py-2 pl-2 text-gray-400 ${props.className}`}>
-            {description}
-          </h2>
+
+          <h2 className={`py-2 pl-2 text-gray-400`}>{description}</h2>
           <div className="overflow-auto p-2">{children}</div>
           <div className="flex justify-end p-2 pt-4">
-            {submitText !== "OK" && (
+            {rightText !== "OK" && (
               <BaseButton
-                id="cancelButton"
-                onClick={() => onCancel()}
+                id="leftButton"
+                onClick={() => onHandleEventLeftButton()}
                 variant="primary"
                 type="button"
                 className="mr-1"
               >
-                {cancelText}
+                {leftText}
               </BaseButton>
             )}
             {hasSubmit && (
               <BaseButton
-                id="submitButton"
-                onClick={() => onSubmit()}
+                id="rightButton"
+                onClick={() => onHandleEventRightButton()}
                 variant="primary"
                 type="button"
                 className="flex"
               >
-                {submitText}
+                {rightText}
               </BaseButton>
             )}
           </div>

--- a/src/components/Dialogs/ErrorDialog.tsx
+++ b/src/components/Dialogs/ErrorDialog.tsx
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import React from "react";
 import ReactDOM from "react-dom";
 import DialogTemplate from "./DialogTemplate";

--- a/src/components/Dialogs/ErrorDialog.tsx
+++ b/src/components/Dialogs/ErrorDialog.tsx
@@ -31,8 +31,8 @@ const ErrorDialog: React.FC<ErrorDialogProps> = ({
     <DialogTemplate
       title="Error"
       description={errorMessage}
-      onSubmit={onClose}
-      submitText="OK"
+      onHandleEventRightButton={onClose}
+      rightButton="OK"
       className="text-lg"
     />,
     document.getElementById("modal-root") as HTMLElement

--- a/src/components/Dialogs/SendTDDialog.tsx
+++ b/src/components/Dialogs/SendTDDialog.tsx
@@ -243,8 +243,8 @@ const SendTDDialog = forwardRef<SendTDDialogRef, SendTDDialogProps>(
       return ReactDOM.createPortal(
         <DialogTemplate
           hasSubmit={false}
-          onCancel={close}
-          cancelText={"Close"}
+          onHandleEventLeftButton={close}
+          leftButton={"Close"}
           title={"Send TD"}
           description={
             "The Thing Description will be sent to a Third-Party Service located at the endpoint configured in the Settings options under Southbound URL field. The proxied Thing will be interactable over HTTP in the left view."

--- a/src/components/Dialogs/SettingsDialog.tsx
+++ b/src/components/Dialogs/SettingsDialog.tsx
@@ -223,10 +223,10 @@ const SettingsDialog = forwardRef<SettingsDialogRef>((_, ref) => {
     return ReactDOM.createPortal(
       <DialogTemplate
         hasSubmit={true}
-        onCancel={close}
-        cancelText={"Cancel"}
-        submitText={"Save Changes"}
-        onSubmit={handleSubmit}
+        onHandleEventLeftButton={close}
+        leftButton={"Cancel"}
+        rightButton={"Save Changes"}
+        onHandleEventRightButton={handleSubmit}
         children={child}
         title={"Settings"}
         description={"Change the ediTDors configuration to your needs"}

--- a/src/components/Dialogs/ShareDialog.tsx
+++ b/src/components/Dialogs/ShareDialog.tsx
@@ -66,10 +66,10 @@ const ShareDialog = forwardRef((_, ref) => {
     return ReactDOM.createPortal(
       <DialogTemplate
         hasSubmit={true}
-        onCancel={close}
-        cancelText={"Okay"}
-        submitText={"Open in Playground"}
-        onSubmit={() => {
+        onHandleEventLeftButton={close}
+        leftButton={"Okay"}
+        rightButton={"Open in Playground"}
+        onHandleEventRightButton={() => {
           window.open(`https://playground.thingweb.io//#${compressedTd}`);
           close();
         }}

--- a/src/components/Dialogs/base/DialogCheckbox.tsx
+++ b/src/components/Dialogs/base/DialogCheckbox.tsx
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 interface ICheckboxProps {
   id: string;
   label: string;

--- a/src/components/Dialogs/base/DialogDropdown.tsx
+++ b/src/components/Dialogs/base/DialogDropdown.tsx
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import { ChevronDown } from "react-feather";
 import React from "react";
 

--- a/src/components/Dialogs/base/DialogTextArea.tsx
+++ b/src/components/Dialogs/base/DialogTextArea.tsx
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 interface ITextAreaProps {
   id: string;
   label: string;

--- a/src/components/Dialogs/base/FormCatalogFields.tsx
+++ b/src/components/Dialogs/base/FormCatalogFields.tsx
@@ -1,0 +1,185 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React from "react";
+import DialogTextField from "./DialogTextField";
+import BaseButton from "../../TDViewer/base/BaseButton";
+import { AlertTriangle, Check, RefreshCw } from "react-feather";
+import InfoIconWrapper from "../../InfoIcon/InfoIconWrapper";
+import { getValidateTMContent } from "../../InfoIcon/TooltipMapper";
+
+interface IFormCatalogFieldsProps {
+  model: string;
+  onChangeModel: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  author: string;
+  onChangeAuthor: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  manufacturer: string;
+  onChangeManufacturer: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  license: string;
+  onChangeLicense: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  copyrightYear: string;
+  onChangeCopyrightYear: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  holder: string;
+  onChangeHolder: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onClickCatalogValidation: () => void;
+  onClickCopyThingModel: () => void;
+  isValidating: boolean;
+  isValid: boolean;
+  errorMessage: string;
+  copied: boolean;
+}
+const FormCatalogFields: React.FC<IFormCatalogFieldsProps> = ({
+  model,
+  onChangeModel,
+  author,
+  onChangeAuthor,
+  manufacturer,
+  onChangeManufacturer,
+  license,
+  onChangeLicense,
+  copyrightYear,
+  onChangeCopyrightYear,
+  holder,
+  onChangeHolder,
+  onClickCatalogValidation,
+  onClickCopyThingModel,
+  isValidating,
+  isValid,
+  errorMessage,
+  copied,
+}) => {
+  return (
+    <>
+      <div className="w-full rounded-md bg-black bg-opacity-80 p-2">
+        <h1 className="font-bold">
+          Add fields for Cataloging to ensure quality and discoverability of
+          Thing Models
+        </h1>
+        <div className="w-[70%] flex-row px-4">
+          <DialogTextField
+            label="Model*"
+            placeholder="The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers."
+            id="model"
+            type="text"
+            value={model}
+            onChange={onChangeModel}
+            autoFocus={true}
+          />
+          <DialogTextField
+            label="Author*"
+            placeholder="The organization writing the TM"
+            id="author"
+            type="text"
+            value={author}
+            onChange={onChangeAuthor}
+            autoFocus={false}
+          />
+          <DialogTextField
+            label="Manufacturer*"
+            placeholder="Manufacturer of the device"
+            id="manufacturer"
+            type="text"
+            value={manufacturer}
+            onChange={onChangeManufacturer}
+            autoFocus={false}
+          />
+          <DialogTextField
+            label="License"
+            placeholder="URL of the license, e.g., https://www.apache.org/licenses/LICENSE-2.0.txt"
+            id="license"
+            type="text"
+            value={license}
+            onChange={onChangeLicense}
+            autoFocus={false}
+          />
+          <DialogTextField
+            label="Copyright Year"
+            placeholder="e.g. 2024..."
+            id="copyright"
+            type="text"
+            value={copyrightYear}
+            onChange={onChangeCopyrightYear}
+            autoFocus={false}
+          />
+          <DialogTextField
+            label="Copyright Holder"
+            placeholder="Organization holding the copyright of the TM..."
+            id="holder"
+            type="text"
+            value={holder}
+            onChange={onChangeHolder}
+            autoFocus={false}
+          />
+          <div className="flex flex-row justify-end">
+            <BaseButton
+              id="catalogValidation"
+              onClick={onClickCatalogValidation}
+              variant="primary"
+              type="button"
+              className="my-2 mt-6 w-1/4"
+            >
+              <div className="flex w-full items-center justify-center">
+                {isValidating ? (
+                  <>
+                    <span className="pl-6">Validating</span>
+                    <RefreshCw className="animate-spin" size={20} />
+                  </>
+                ) : (
+                  <>
+                    <span className="pl-6">Validate</span>
+                    <InfoIconWrapper
+                      tooltip={getValidateTMContent()}
+                      id="validateTMContent"
+                    />
+                  </>
+                )}
+              </div>
+            </BaseButton>
+          </div>
+        </div>
+
+        <div>
+          {errorMessage && (
+            <div className="mb-2 mt-2 h-full w-full rounded bg-red-500 p-1 text-white">
+              <AlertTriangle size={16} className="mr-1 inline" />
+              {errorMessage}
+            </div>
+          )}
+          {isValid && (
+            <>
+              <div className="flex flex-col">
+                <div className="m-2 inline rounded bg-green-500 p-2 text-white">
+                  <Check size={16} className="mr-1 inline" />
+                  {"TM is valid"}
+                </div>
+                <div>
+                  <BaseButton
+                    id="copyThingModel"
+                    onClick={onClickCopyThingModel}
+                    variant="primary"
+                    type="button"
+                    className="mx-2 my-4"
+                  >
+                    {copied
+                      ? "Copied Thing Model"
+                      : "Click to copy the full Thing Model"}
+                  </BaseButton>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+export default FormCatalogFields;

--- a/src/components/Dialogs/base/FormCatalogFields.tsx
+++ b/src/components/Dialogs/base/FormCatalogFields.tsx
@@ -64,7 +64,7 @@ const FormCatalogFields: React.FC<IFormCatalogFieldsProps> = ({
           Add fields for Cataloging to ensure quality and discoverability of
           Thing Models
         </h1>
-        <div className="w-[70%] flex-row px-4">
+        <div className="mx-auto w-[70%] flex-col px-4">
           <DialogTextField
             label="Model*"
             placeholder="The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers."

--- a/src/components/Dialogs/base/FormCatalogFields.tsx
+++ b/src/components/Dialogs/base/FormCatalogFields.tsx
@@ -61,8 +61,9 @@ const FormCatalogFields: React.FC<IFormCatalogFieldsProps> = ({
     <>
       <div className="w-full rounded-md bg-black bg-opacity-80 p-2">
         <h1 className="font-bold">
-          Add fields for Cataloging to ensure quality and discoverability of
-          Thing Models
+          The following fields will be added in the background to your TM for
+          cataloging purposes to ensure quality and discoverability of Thing
+          Models.
         </h1>
         <div className="mx-auto w-[70%] flex-col px-4">
           <DialogTextField

--- a/src/components/Dialogs/base/FormCatalogTmEndpoints.tsx
+++ b/src/components/Dialogs/base/FormCatalogTmEndpoints.tsx
@@ -58,7 +58,7 @@ const FormCatalogTmEndpoints: React.FC<IFormCatalogTMEndpoints> = ({
         <h1 className="font-bold">
           Add the TM Catalog Endpoint and Repository URL
         </h1>
-        <div className="w-[70%] px-4">
+        <div className="mx-auto w-[70%] flex-col px-4">
           <DialogTextField
             label="TM Catalog Endpoint"
             placeholder="TM Catalog Endpoint:..."

--- a/src/components/Dialogs/base/FormCatalogTmEndpoints.tsx
+++ b/src/components/Dialogs/base/FormCatalogTmEndpoints.tsx
@@ -1,0 +1,165 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React from "react";
+import DialogTextField from "./DialogTextField";
+import BaseButton from "../../TDViewer/base/BaseButton";
+import { AlertTriangle, Check, Copy, ExternalLink } from "react-feather";
+
+interface IFormCatalogTMEndpoints {
+  tmCatalogEndpoint: string;
+  tmCatalogEndpointError: string;
+  handleTmCatalogEndpointChange: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => void;
+  repository: string;
+  repositoryError: string;
+  handleRepositoryChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleSubmit: () => void;
+  submittedError: string;
+  submitted: boolean;
+  id: string;
+  link: string;
+}
+
+const FormCatalogTmEndpoints: React.FC<IFormCatalogTMEndpoints> = ({
+  tmCatalogEndpoint,
+  tmCatalogEndpointError,
+  handleTmCatalogEndpointChange,
+  repository,
+  repositoryError,
+  handleRepositoryChange,
+  handleSubmit,
+  submittedError,
+  submitted,
+  id,
+  link,
+}) => {
+  const handleOpenLinkClick = async () => {
+    window.open(link, "_blank", "noopener,noreferrer");
+  };
+
+  const handleCopyIdClick = async () => {
+    await navigator.clipboard.writeText(id);
+  };
+
+  return (
+    <>
+      <div className="w-full rounded-md bg-black bg-opacity-80 p-2">
+        <h1 className="font-bold">
+          Add the TM Catalog Endpoint and Repository URL
+        </h1>
+        <div className="w-[70%] px-4">
+          <DialogTextField
+            label="TM Catalog Endpoint"
+            placeholder="TM Catalog Endpoint:..."
+            id="catalogEndpoint"
+            type="text"
+            value={tmCatalogEndpoint}
+            autoFocus={false}
+            onChange={handleTmCatalogEndpointChange}
+            className={`${
+              tmCatalogEndpointError ? "border-red-500" : "border-gray-300"
+            } w-full rounded-md border p-2 text-sm`}
+          />
+          {tmCatalogEndpointError && (
+            <div className="mt-1 text-sm text-red-500">
+              {tmCatalogEndpointError}
+            </div>
+          )}
+          <DialogTextField
+            label="Name of the Repository"
+            placeholder="In case there are multiple repositories hosted, specify which one with a string. Example: my-catalog"
+            id="urlRepository"
+            type="text"
+            value={repository}
+            autoFocus={false}
+            onChange={handleRepositoryChange}
+            className={`${
+              repositoryError ? "border-red-500" : "border-gray-300"
+            } w-full rounded-md border p-2 text-sm`}
+          />
+          {repositoryError && (
+            <div className="mt-1 text-sm text-red-500">{repositoryError}</div>
+          )}
+          <div className="flex flex-row justify-end">
+            <BaseButton
+              id="submit"
+              onClick={handleSubmit}
+              variant="primary"
+              type="button"
+              className="mb-2 mt-6 w-1/4"
+            >
+              Submit
+            </BaseButton>
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-center py-2">
+          {submittedError && (
+            <div className="mb-2 mt-2 inline h-full w-full rounded bg-red-500 p-1 text-white">
+              <AlertTriangle size={16} className="mr-1 inline" />
+              {submittedError}
+            </div>
+          )}
+          {submitted && (
+            <>
+              <div className="mb-2 mt-2 inline h-10 rounded bg-green-500 p-2 text-white">
+                <Check size={16} className="mr-1 inline" />
+                {"TM submitted successfully!"}
+              </div>
+              <div className="mb-2 mt-2 grid grid-cols-3 items-center">
+                <div className="col-span-1 w-full">
+                  <BaseButton
+                    id={id}
+                    onClick={handleCopyIdClick}
+                    variant="primary"
+                    type="button"
+                    className="w-3/4"
+                  >
+                    <div className="flex w-full items-center justify-between">
+                      <span>Copy TM id</span>
+                      <Copy size={20} className="ml-2 cursor-pointer" />
+                    </div>
+                  </BaseButton>
+                </div>
+                <h1 className="col-span-2 pl-4 text-center">{id}</h1>
+              </div>
+              <div className="mb-2 mt-2 grid grid-cols-3 items-center">
+                <div className="col-span-1">
+                  <BaseButton
+                    id={link}
+                    onClick={handleOpenLinkClick}
+                    variant="primary"
+                    type="button"
+                    className="w-3/4"
+                  >
+                    <div className="flex w-full items-center justify-between">
+                      <span>Open in new tab</span>
+                      <ExternalLink
+                        size={20}
+                        className="ml-2 inline cursor-pointer"
+                      />
+                    </div>
+                  </BaseButton>
+                </div>
+                <h1 className="col-span-2 pl-4 text-center">{link}</h1>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FormCatalogTmEndpoints;

--- a/src/components/Dialogs/base/FormField.tsx
+++ b/src/components/Dialogs/base/FormField.tsx
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
 import React from "react";
 
 interface FormFieldProps {

--- a/src/components/Dialogs/base/FormInteraction.tsx
+++ b/src/components/Dialogs/base/FormInteraction.tsx
@@ -23,6 +23,7 @@ import { getLocalStorage } from "../../../services/localStorage";
 import { getErrorSummary } from "../../../utils/arrays";
 import Settings, { SettingsData } from "../../App/Settings";
 import { ChevronDown, ChevronUp } from "react-feather";
+import TmInputForm from "../../App/TmInputForm";
 
 interface ErrorAllRequests {
   firstError: {
@@ -31,6 +32,8 @@ interface ErrorAllRequests {
   };
   errorCount: number;
 }
+
+type ActiveSection = "instance" | "gateway" | "table" | "savingResults";
 
 interface FormInteractionProps {
   filteredHeaders: { key: string; text: string }[];
@@ -61,13 +64,17 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
     pathToValue: getLocalStorage("valuePath") || "/",
   });
 
-  const [instanceSectionExpanded, setInstanceSectionExpanded] = useState(true);
-  const [gatewaySectionExpanded, setGatewaySectionExpanded] = useState(false);
-  const [tableSectionExpanded, setTableSectionExpanded] = useState(false);
-  const [savingSectionExpanded, setSavingSectionExpanded] = useState(false);
+  const [activeSection, setActiveSection] = useState<ActiveSection>("instance");
 
   const [testingExpanded, setTestingExpanded] = useState(true);
 
+  const toggleSection = (sectionName: ActiveSection) => {
+    if (activeSection === sectionName) {
+      setActiveSection("instance");
+    } else {
+      setActiveSection(sectionName);
+    }
+  };
   const handleTestAllProperties = async () => {
     setIsTestingAll(true);
     const results = { ...allRequestResults };
@@ -148,6 +155,9 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
       setSettingsData(data);
     }
   };
+  const handleOnChangeValues = (values: Record<string, string>) => {
+    console.log("Received values from TmInputForm:", values);
+  };
 
   return (
     <>
@@ -160,48 +170,59 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
             instance-specific information such as IP address.
           </p>
         </div>
-        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+        <div
+          id="instanceSection"
+          className="overflow-hidden rounded-md bg-black bg-opacity-80"
+        >
           <div
             className="flex cursor-pointer items-center p-2 font-bold"
-            onClick={() => setInstanceSectionExpanded(!instanceSectionExpanded)}
+            onClick={() => toggleSection("instance")}
           >
             <ChevronDown
               size={16}
-              className={`mr-2 transition-transform duration-200 ${instanceSectionExpanded ? "rotate-0" : "-rotate-90"}`}
+              className={`mr-2 transition-transform duration-200 ${activeSection === "instance" ? "rotate-0" : "-rotate-90"}`}
             />
             <span className="flex-grow"> 2.1 Instance</span>
-            {instanceSectionExpanded ? (
+            {activeSection === "instance" ? (
               <ChevronDown size={16} />
             ) : (
               <ChevronUp size={16} />
             )}
           </div>
 
-          {instanceSectionExpanded && (
-            <div className="p-2 pt-0">
-              <div className="mx-auto w-[70%]"></div>
+          {activeSection === "instance" && (
+            <div className="w-full p-2">
+              <div className="mx-auto mb-2 w-[70%]">
+                <TmInputForm
+                  tmContent={context.offlineTD}
+                  onValueUpdate={handleOnChangeValues}
+                />
+              </div>
             </div>
           )}
         </div>
 
-        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+        <div
+          id="gatewaySection"
+          className="overflow-hidden rounded-md bg-black bg-opacity-80"
+        >
           <div
             className="flex cursor-pointer items-center p-2 font-bold"
-            onClick={() => setGatewaySectionExpanded(!gatewaySectionExpanded)}
+            onClick={() => toggleSection("gateway")}
           >
             <ChevronDown
               size={16}
-              className={`mr-2 transition-transform duration-200 ${gatewaySectionExpanded ? "rotate-0" : "-rotate-90"}`}
+              className={`mr-2 transition-transform duration-200 ${activeSection === "gateway" ? "rotate-0" : "-rotate-90"}`}
             />
             <span className="flex-grow"> 2.2 Gateway</span>
-            {gatewaySectionExpanded ? (
+            {activeSection === "gateway" ? (
               <ChevronDown size={16} />
             ) : (
               <ChevronUp size={16} />
             )}
           </div>
 
-          {gatewaySectionExpanded && (
+          {activeSection === "gateway" && (
             <div className="w-full p-2">
               <div className="mx-auto mt-4 w-[70%]">
                 <Settings
@@ -213,24 +234,27 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
           )}
         </div>
 
-        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+        <div
+          id="tableSection"
+          className="overflow-hidden rounded-md bg-black bg-opacity-80"
+        >
           <div
             className="flex cursor-pointer items-center p-2 font-bold"
-            onClick={() => setTableSectionExpanded(!tableSectionExpanded)}
+            onClick={() => toggleSection("table")}
           >
             <ChevronDown
               size={16}
-              className={`mr-2 transition-transform duration-200 ${tableSectionExpanded ? "rotate-0" : "-rotate-90"}`}
+              className={`mr-2 transition-transform duration-200 ${activeSection === "table" ? "rotate-0" : "-rotate-90"}`}
             />
             <span className="flex-grow"> 2.3 Table</span>
-            {tableSectionExpanded ? (
+            {activeSection === "table" ? (
               <ChevronDown size={16} />
             ) : (
               <ChevronUp size={16} />
             )}
           </div>
 
-          {tableSectionExpanded && (
+          {activeSection === "table" && (
             <div className="mt-4 w-full p-2">
               <h1 className="font-bold">Test endpoints on properties</h1>
               <div className="p-2">
@@ -283,26 +307,29 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
           )}
         </div>
 
-        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+        <div
+          id="savingResultsSection"
+          className="overflow-hidden rounded-md bg-black bg-opacity-80"
+        >
           <div
             className="flex cursor-pointer items-center p-2 font-bold"
-            onClick={() => setSavingSectionExpanded(!savingSectionExpanded)}
+            onClick={() => toggleSection("savingResults")}
           >
             <ChevronDown
               size={16}
-              className={`mr-2 transition-transform duration-200 ${savingSectionExpanded ? "rotate-0" : "-rotate-90"}`}
+              className={`mr-2 transition-transform duration-200 ${activeSection === "savingResults" ? "rotate-0" : "-rotate-90"}`}
             />
             <span className="flex-grow"> 2.4 Saving results</span>
-            {savingSectionExpanded ? (
+            {activeSection === "savingResults" ? (
               <ChevronDown size={16} />
             ) : (
               <ChevronUp size={16} />
             )}
           </div>
 
-          {savingSectionExpanded && (
+          {activeSection === "savingResults" && (
             <div className="p-2 pt-0">
-              <div className="mx-auto w-[70%]"></div>
+              <div className="mx-auto w-[70%]">Saving Results ...</div>
             </div>
           )}
         </div>

--- a/src/components/Dialogs/base/FormInteraction.tsx
+++ b/src/components/Dialogs/base/FormInteraction.tsx
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { RefreshCw } from "react-feather";
 import type { ThingDescription } from "wot-thing-description-types";
 
@@ -19,7 +19,10 @@ import BaseTable from "../../TDViewer/base/BaseTable";
 import BaseButton from "../../TDViewer/base/BaseButton";
 import { readPropertyWithServient } from "../../../services/form";
 import { extractIndexFromId } from "../../../utils/strings";
-import { getLocalStorage } from "../../../services/localStorage";
+import {
+  getLocalStorage,
+  setLocalStorage,
+} from "../../../services/localStorage";
 import { getErrorSummary } from "../../../utils/arrays";
 import Settings, { SettingsData } from "../../App/Settings";
 import { ChevronDown, ChevronUp } from "react-feather";
@@ -44,6 +47,8 @@ interface FormInteractionProps {
   >;
   errorAllRequests: ErrorAllRequests;
   setErrorAllRequests: React.Dispatch<React.SetStateAction<ErrorAllRequests>>;
+  placeholderValues?: Record<string, string>;
+  handleFieldChange: (placeholder: string, value: string) => void;
 }
 
 const FormInteraction: React.FC<FormInteractionProps> = ({
@@ -53,6 +58,8 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
   setAllRequestResults,
   errorAllRequests,
   setErrorAllRequests,
+  placeholderValues = {},
+  handleFieldChange,
 }) => {
   const context = useContext(ediTDorContext);
   const td: ThingDescription = context.parsedTD;
@@ -66,7 +73,11 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
 
   const [activeSection, setActiveSection] = useState<ActiveSection>("instance");
 
-  const [testingExpanded, setTestingExpanded] = useState(true);
+  useEffect(() => {
+    setLocalStorage(settingsData.northboundUrl, "northbound");
+    setLocalStorage(settingsData.southboundUrl, "southbound");
+    setLocalStorage(settingsData.pathToValue, "valuePath");
+  }, [settingsData]);
 
   const toggleSection = (sectionName: ActiveSection) => {
     if (activeSection === sectionName) {
@@ -74,7 +85,11 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
     } else {
       setActiveSection(sectionName);
     }
+    // if (activeSection === "instance") {
+    //updateTD;
+    //}
   };
+
   const handleTestAllProperties = async () => {
     setIsTestingAll(true);
     const results = { ...allRequestResults };
@@ -155,9 +170,6 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
       setSettingsData(data);
     }
   };
-  const handleOnChangeValues = (values: Record<string, string>) => {
-    console.log("Received values from TmInputForm:", values);
-  };
 
   return (
     <>
@@ -190,16 +202,17 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
             )}
           </div>
 
-          {activeSection === "instance" && (
-            <div className="w-full p-2">
-              <div className="mx-auto mb-2 w-[70%]">
-                <TmInputForm
-                  tmContent={context.offlineTD}
-                  onValueUpdate={handleOnChangeValues}
-                />
+          {activeSection === "instance" &&
+            Object.keys(placeholderValues).length > 0 && (
+              <div className="w-full p-2">
+                <div className="mx-auto mb-2 w-[70%]">
+                  <TmInputForm
+                    inputValues={placeholderValues}
+                    onValueChange={handleFieldChange}
+                  />
+                </div>
               </div>
-            </div>
-          )}
+            )}
         </div>
 
         <div

--- a/src/components/Dialogs/base/FormInteraction.tsx
+++ b/src/components/Dialogs/base/FormInteraction.tsx
@@ -119,13 +119,15 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
   useEffect(() => {
     const updateBackgroundTd = async () => {
       if (activeSection === "table") {
-        let backgroundTdToSendStringify = JSON.stringify(context.parsedTD);
-        let newGeneratedTm = backgroundTdToSendStringify;
+        let backgroundTdToSendStringify = JSON.stringify(backgroundTdToSend);
+        let newGeneratedTm: string;
         if (placeholderValues && Object.keys(placeholderValues).length > 0) {
           newGeneratedTm = replacePlaceholders(
             backgroundTdToSendStringify,
             placeholderValues
           );
+        } else {
+          newGeneratedTm = backgroundTdToSendStringify;
         }
         // Gives an error when id have "/"
         // Check the parsing errors on placeholders when they have "{{}}" and only {{}}
@@ -150,11 +152,8 @@ const FormInteraction: React.FC<FormInteractionProps> = ({
         try {
           const url = getLocalStorage("southbound");
           if (!url) throw new Error("Southbound Url must be defined");
-          // Sanitation of URL
-          const endpoint = `${url}`;
-
           const response = await handleHttpRequest(
-            `${endpoint}`,
+            `${url}`,
             "POST",
             JSON.stringify(backgroundTdToSend)
           );

--- a/src/components/Dialogs/base/FormInteraction.tsx
+++ b/src/components/Dialogs/base/FormInteraction.tsx
@@ -1,0 +1,314 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React, { useState, useContext } from "react";
+import { RefreshCw } from "react-feather";
+import type { ThingDescription } from "wot-thing-description-types";
+
+import ediTDorContext from "../../../context/ediTDorContext";
+import BaseTable from "../../TDViewer/base/BaseTable";
+import BaseButton from "../../TDViewer/base/BaseButton";
+import { readPropertyWithServient } from "../../../services/form";
+import { extractIndexFromId } from "../../../utils/strings";
+import { getLocalStorage } from "../../../services/localStorage";
+import { getErrorSummary } from "../../../utils/arrays";
+import Settings, { SettingsData } from "../../App/Settings";
+import { ChevronDown, ChevronUp } from "react-feather";
+
+interface ErrorAllRequests {
+  firstError: {
+    id: string;
+    message: string;
+  };
+  errorCount: number;
+}
+
+interface FormInteractionProps {
+  filteredHeaders: { key: string; text: string }[];
+  filteredRows: any[];
+  allRequestResults: { [id: string]: { value: string; error: string } };
+  setAllRequestResults: React.Dispatch<
+    React.SetStateAction<{ [id: string]: { value: string; error: string } }>
+  >;
+  errorAllRequests: ErrorAllRequests;
+  setErrorAllRequests: React.Dispatch<React.SetStateAction<ErrorAllRequests>>;
+}
+
+const FormInteraction: React.FC<FormInteractionProps> = ({
+  filteredHeaders,
+  filteredRows,
+  allRequestResults,
+  setAllRequestResults,
+  errorAllRequests,
+  setErrorAllRequests,
+}) => {
+  const context = useContext(ediTDorContext);
+  const td: ThingDescription = context.parsedTD;
+
+  const [isTestingAll, setIsTestingAll] = useState<boolean>(false);
+  const [settingsData, setSettingsData] = useState<SettingsData>({
+    northboundUrl: getLocalStorage("northbound") || "",
+    southboundUrl: getLocalStorage("southbound") || "",
+    pathToValue: getLocalStorage("valuePath") || "/",
+  });
+
+  const [instanceSectionExpanded, setInstanceSectionExpanded] = useState(true);
+  const [gatewaySectionExpanded, setGatewaySectionExpanded] = useState(false);
+  const [tableSectionExpanded, setTableSectionExpanded] = useState(false);
+  const [savingSectionExpanded, setSavingSectionExpanded] = useState(false);
+
+  const [testingExpanded, setTestingExpanded] = useState(true);
+
+  const handleTestAllProperties = async () => {
+    setIsTestingAll(true);
+    const results = { ...allRequestResults };
+
+    for (const item of filteredRows) {
+      try {
+        const res = await readPropertyWithServient(
+          td,
+          item.propName,
+          {
+            formIndex: extractIndexFromId(item.id as string),
+          },
+          settingsData.pathToValue
+        );
+
+        if (res.err) {
+          results[item.id] = { value: "", error: res.err.message };
+        } else {
+          results[item.id] = { value: res.result, error: "" };
+        }
+      } catch (err: any) {
+        results[item.id] = { value: "", error: err.message };
+      }
+    }
+
+    setAllRequestResults(results);
+    const { firstError, errorCount } = getErrorSummary(results);
+    if (errorCount > 0) {
+      setErrorAllRequests({ firstError, errorCount });
+    }
+    setIsTestingAll(false);
+  };
+
+  const handleOnClickSendRequest = async (item: {
+    [key: string]: any;
+  }): Promise<{ value: string; error: string }> => {
+    const index = extractIndexFromId(item.id);
+
+    if (Object.keys(context.northboundConnection.northboundTd).length > 0) {
+      try {
+        const res = await readPropertyWithServient(
+          context.northboundConnection.northboundTd as ThingDescription,
+          item.propName,
+          {
+            formIndex: index,
+          },
+          settingsData.pathToValue
+        );
+        if (res.err) {
+          return { value: "", error: res.err.message };
+        }
+        return { value: res.result, error: "" };
+      } catch (err: any) {
+        return { value: "", error: err.message };
+      }
+    } else {
+      try {
+        const res = await readPropertyWithServient(
+          td,
+          item.propName,
+          {
+            formIndex: index,
+          },
+          settingsData.pathToValue
+        );
+        if (res.err) {
+          return { value: "", error: res.err.message };
+        }
+        return { value: res.result, error: "" };
+      } catch (err: any) {
+        return { value: "", error: err.message };
+      }
+    }
+  };
+
+  const handleSettingsChange = (data: SettingsData, valid: boolean) => {
+    if (valid) {
+      setSettingsData(data);
+    }
+  };
+
+  return (
+    <>
+      <div className="space-y-4">
+        <div className="mb-2 w-full rounded-md bg-opacity-80 p-3 text-white">
+          <p className="text-lg">
+            If you want to verify the correctness of your model, you can
+            interact with a device instance here. To do so, please configure the
+            proxy (northbound, southound, valuepath) and provide
+            instance-specific information such as IP address.
+          </p>
+        </div>
+        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+          <div
+            className="flex cursor-pointer items-center p-2 font-bold"
+            onClick={() => setInstanceSectionExpanded(!instanceSectionExpanded)}
+          >
+            <ChevronDown
+              size={16}
+              className={`mr-2 transition-transform duration-200 ${instanceSectionExpanded ? "rotate-0" : "-rotate-90"}`}
+            />
+            <span className="flex-grow"> 2.1 Instance</span>
+            {instanceSectionExpanded ? (
+              <ChevronDown size={16} />
+            ) : (
+              <ChevronUp size={16} />
+            )}
+          </div>
+
+          {instanceSectionExpanded && (
+            <div className="p-2 pt-0">
+              <div className="mx-auto w-[70%]"></div>
+            </div>
+          )}
+        </div>
+
+        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+          <div
+            className="flex cursor-pointer items-center p-2 font-bold"
+            onClick={() => setGatewaySectionExpanded(!gatewaySectionExpanded)}
+          >
+            <ChevronDown
+              size={16}
+              className={`mr-2 transition-transform duration-200 ${gatewaySectionExpanded ? "rotate-0" : "-rotate-90"}`}
+            />
+            <span className="flex-grow"> 2.2 Gateway</span>
+            {gatewaySectionExpanded ? (
+              <ChevronDown size={16} />
+            ) : (
+              <ChevronUp size={16} />
+            )}
+          </div>
+
+          {gatewaySectionExpanded && (
+            <div className="w-full p-2">
+              <div className="mx-auto mt-4 w-[70%]">
+                <Settings
+                  initialData={settingsData}
+                  onChange={handleSettingsChange}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+          <div
+            className="flex cursor-pointer items-center p-2 font-bold"
+            onClick={() => setTableSectionExpanded(!tableSectionExpanded)}
+          >
+            <ChevronDown
+              size={16}
+              className={`mr-2 transition-transform duration-200 ${tableSectionExpanded ? "rotate-0" : "-rotate-90"}`}
+            />
+            <span className="flex-grow"> 2.3 Table</span>
+            {tableSectionExpanded ? (
+              <ChevronDown size={16} />
+            ) : (
+              <ChevronUp size={16} />
+            )}
+          </div>
+
+          {tableSectionExpanded && (
+            <div className="mt-4 w-full p-2">
+              <h1 className="font-bold">Test endpoints on properties</h1>
+              <div className="p-2">
+                <BaseTable
+                  headers={filteredHeaders}
+                  items={filteredRows}
+                  itemsPerPage={10}
+                  orderBy=""
+                  order="asc"
+                  baseUrl={td.base ?? ""}
+                  expandTable={true}
+                  onSendRequestClick={handleOnClickSendRequest}
+                  requestResults={allRequestResults}
+                />
+              </div>
+              <div className="mb-4 mt-2 flex justify-end px-4">
+                <BaseButton
+                  onClick={handleTestAllProperties}
+                  variant="primary"
+                  type="button"
+                  disabled={isTestingAll}
+                  className="flex items-center"
+                >
+                  {isTestingAll ? (
+                    <>
+                      <RefreshCw className="mr-2 animate-spin" size={16} />
+                      Testing...
+                    </>
+                  ) : (
+                    "Test All Properties"
+                  )}
+                </BaseButton>
+              </div>
+              {errorAllRequests?.errorCount > 0 && (
+                <div className="mt-4 rounded-md bg-red-100 p-3 text-red-700">
+                  <p className="font-bold">
+                    Found {errorAllRequests.errorCount} error
+                    {errorAllRequests.errorCount > 1 ? "s" : ""}
+                  </p>
+                  <p className="mt-1">
+                    First error in property name{" "}
+                    <span className="font-semibold">
+                      {errorAllRequests.firstError.id}
+                    </span>
+                    :{errorAllRequests.firstError.message}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="overflow-hidden rounded-md bg-black bg-opacity-80">
+          <div
+            className="flex cursor-pointer items-center p-2 font-bold"
+            onClick={() => setSavingSectionExpanded(!savingSectionExpanded)}
+          >
+            <ChevronDown
+              size={16}
+              className={`mr-2 transition-transform duration-200 ${savingSectionExpanded ? "rotate-0" : "-rotate-90"}`}
+            />
+            <span className="flex-grow"> 2.4 Saving results</span>
+            {savingSectionExpanded ? (
+              <ChevronDown size={16} />
+            ) : (
+              <ChevronUp size={16} />
+            )}
+          </div>
+
+          {savingSectionExpanded && (
+            <div className="p-2 pt-0">
+              <div className="mx-auto w-[70%]"></div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FormInteraction;

--- a/src/components/Dialogs/base/FormMetadata.tsx
+++ b/src/components/Dialogs/base/FormMetadata.tsx
@@ -154,7 +154,7 @@ const FormMetadata: React.FC<IFormMetadataProps> = ({
         <div>
           {errorMessage && (
             <div className="mb-2 mt-2 h-full w-full rounded bg-red-500 p-1 text-white">
-              <AlertTriangle size={16} className="mr-1 inline" />
+              <AlertTriangle size={24} className="mr-1 inline text-black" />
               {errorMessage}
             </div>
           )}

--- a/src/components/Dialogs/base/FormMetadata.tsx
+++ b/src/components/Dialogs/base/FormMetadata.tsx
@@ -17,7 +17,7 @@ import { AlertTriangle, Check, RefreshCw } from "react-feather";
 import InfoIconWrapper from "../../InfoIcon/InfoIconWrapper";
 import { getValidateTMContent } from "../../InfoIcon/TooltipMapper";
 
-interface IFormCatalogFieldsProps {
+interface IFormMetadataProps {
   model: string;
   onChangeModel: (event: React.ChangeEvent<HTMLInputElement>) => void;
   author: string;
@@ -37,7 +37,7 @@ interface IFormCatalogFieldsProps {
   errorMessage: string;
   copied: boolean;
 }
-const FormCatalogFields: React.FC<IFormCatalogFieldsProps> = ({
+const FormMetadata: React.FC<IFormMetadataProps> = ({
   model,
   onChangeModel,
   author,
@@ -183,4 +183,4 @@ const FormCatalogFields: React.FC<IFormCatalogFieldsProps> = ({
     </>
   );
 };
-export default FormCatalogFields;
+export default FormMetadata;

--- a/src/components/Dialogs/base/FormMetadata.tsx
+++ b/src/components/Dialogs/base/FormMetadata.tsx
@@ -121,6 +121,13 @@ const FormMetadata: React.FC<IFormMetadataProps> = ({
             autoFocus={false}
           />
           <div className="flex flex-row justify-end">
+            <div className="my-2 mt-6 flex flex-grow justify-end">
+              <InfoIconWrapper
+                tooltip={getValidateTMContent()}
+                id="validateTMContent"
+                className="justify-center"
+              />
+            </div>
             <BaseButton
               id="catalogValidation"
               onClick={onClickCatalogValidation}
@@ -137,10 +144,6 @@ const FormMetadata: React.FC<IFormMetadataProps> = ({
                 ) : (
                   <>
                     <span className="pl-6">Validate</span>
-                    <InfoIconWrapper
-                      tooltip={getValidateTMContent()}
-                      id="validateTMContent"
-                    />
                   </>
                 )}
               </div>

--- a/src/components/Dialogs/base/FormSubmission.tsx
+++ b/src/components/Dialogs/base/FormSubmission.tsx
@@ -15,7 +15,7 @@ import DialogTextField from "./DialogTextField";
 import BaseButton from "../../TDViewer/base/BaseButton";
 import { AlertTriangle, Check, Copy, ExternalLink } from "react-feather";
 
-interface IFormCatalogTMEndpoints {
+interface IFormSubmissionProps {
   tmCatalogEndpoint: string;
   tmCatalogEndpointError: string;
   handleTmCatalogEndpointChange: (
@@ -31,7 +31,7 @@ interface IFormCatalogTMEndpoints {
   link: string;
 }
 
-const FormCatalogTmEndpoints: React.FC<IFormCatalogTMEndpoints> = ({
+const FormSubmission: React.FC<IFormSubmissionProps> = ({
   tmCatalogEndpoint,
   tmCatalogEndpointError,
   handleTmCatalogEndpointChange,
@@ -162,4 +162,4 @@ const FormCatalogTmEndpoints: React.FC<IFormCatalogTMEndpoints> = ({
   );
 };
 
-export default FormCatalogTmEndpoints;
+export default FormSubmission;

--- a/src/components/Dialogs/base/ProgressBar.tsx
+++ b/src/components/Dialogs/base/ProgressBar.tsx
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React, { createContext, useContext, ReactNode, Children } from "react";
+import { twMerge } from "tailwind-merge";
+
+interface ProgressContextType {
+  percent: number;
+  stepCount: number;
+  currentIndex: number;
+}
+
+const ProgressContext = createContext<ProgressContextType>({
+  percent: 0,
+  stepCount: 0,
+  currentIndex: 0,
+});
+
+interface ProgressBarProps {
+  percent: number;
+  filledBackground?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({
+  percent,
+  filledBackground = "linear-gradient(to right, #A8B988, #B5D7BD)",
+  children,
+  className,
+}) => {
+  const childrenArray = Children.toArray(children);
+  const stepCount = childrenArray.length;
+  const currentIndex = Math.floor((percent / 100) * stepCount);
+
+  const childrenWithIndices = Children.map(children, (child, index) => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, { stepIndex: index } as any);
+    }
+    return child;
+  });
+
+  return (
+    <ProgressContext.Provider value={{ percent, stepCount, currentIndex }}>
+      <div className={twMerge("relative mb-6 h-8 w-full", className)}>
+        <div className="absolute left-0 top-1/2 h-2 w-full -translate-y-1/2 rounded-full bg-gray-200"></div>
+        <div
+          className="absolute left-0 top-1/2 h-2 -translate-y-1/2 rounded-full transition-all duration-300 ease-in-out"
+          style={{
+            width: `${percent}%`,
+            background: filledBackground,
+          }}
+        ></div>
+
+        <div className="absolute left-0 top-0 flex w-full items-center justify-between">
+          {childrenWithIndices}
+        </div>
+      </div>
+    </ProgressContext.Provider>
+  );
+};
+
+interface StepProps {
+  children: (props: { accomplished: boolean; index: number }) => ReactNode;
+  transition?: string;
+  className?: string;
+  stepIndex?: number;
+}
+
+export const Step: React.FC<StepProps> = ({
+  children,
+  transition = "scale",
+  className,
+  stepIndex = 0,
+}) => {
+  const { currentIndex } = useContext(ProgressContext);
+
+  const accomplished = stepIndex <= currentIndex;
+
+  const scaleClass =
+    transition === "scale" && accomplished ? "scale-110" : "scale-100";
+
+  return (
+    <div
+      data-step={stepIndex}
+      className={twMerge("transition-all duration-300", scaleClass, className)}
+    >
+      {children({ accomplished, index: stepIndex })}
+    </div>
+  );
+};

--- a/src/components/InfoIcon/InfoIconWrapper.tsx
+++ b/src/components/InfoIcon/InfoIconWrapper.tsx
@@ -37,21 +37,29 @@ const InfoIconWrapper: React.FC<IInfoIconWrapperProps> = (props) => {
       ? `flex ${props.className}`
       : "flex justify-center";
 
+  const handleClick = () => {
+    if (!isHrefEmpty) {
+      window.open(props.tooltip.href, "_blank");
+    }
+  };
+
   return (
     <div className={containerClass}>
       <div className="pr-0.5">{props.children}</div>
-      <button
-        onClick={() =>
-          !isHrefEmpty && window.open(props.tooltip.href, "_blank")
-        }
-        disabled={isHrefEmpty}
+      <div
+        role="link"
+        tabIndex={isHrefEmpty ? -1 : 0}
+        onClick={handleClick}
+        aria-disabled={isHrefEmpty}
+        className={`cursor-${isHrefEmpty ? "default" : "pointer"}`}
+        aria-label={isHrefEmpty ? "Info" : "More information"}
       >
         <Icon
           html={props.tooltip.html || "No tooltip content available"}
           id={props.id}
           IconComponent={Info}
         />
-      </button>
+      </div>
       <div className="p-1"></div>
     </div>
   );

--- a/src/components/TDViewer/TDViewer.tsx
+++ b/src/components/TDViewer/TDViewer.tsx
@@ -33,13 +33,18 @@ import type { ThingDescription } from "wot-thing-description-types";
 interface ITDViewerProps {
   onUndo: () => void;
   onRedo: () => void;
+  customBreakpoints: number;
 }
 
 interface IAddFormDialogRef {
   openModal: () => void;
 }
 
-const TDViewer: React.FC<ITDViewerProps> = ({ onUndo, onRedo }) => {
+const TDViewer: React.FC<ITDViewerProps> = ({
+  onUndo,
+  onRedo,
+  customBreakpoints,
+}) => {
   const context = useContext(ediTDorContext);
   const td: ThingDescription = context.parsedTD;
   const alreadyRenderedKeys = [
@@ -186,7 +191,10 @@ const TDViewer: React.FC<ITDViewerProps> = ({ onUndo, onRedo }) => {
 
       <LinkSection />
 
-      <InteractionSection interaction="Properties"></InteractionSection>
+      <InteractionSection
+        interaction="Properties"
+        customBreakpoints={customBreakpoints}
+      ></InteractionSection>
       <InteractionSection interaction="Actions"></InteractionSection>
       <InteractionSection interaction="Events"></InteractionSection>
 

--- a/src/components/TDViewer/base/BasePagination.tsx
+++ b/src/components/TDViewer/base/BasePagination.tsx
@@ -19,6 +19,7 @@ interface BasePaginationProps<T> {
   filter?: (value: T, index: number, array: T[]) => boolean;
   onItemsChange?: (items: T[]) => void;
   children: (props: { items: T[] }) => React.ReactNode;
+  pagesWithErrors?: Set<number>;
 }
 
 const BasePagination = <T,>({
@@ -28,6 +29,7 @@ const BasePagination = <T,>({
   filter = () => true,
   onItemsChange,
   children,
+  pagesWithErrors = new Set(),
 }: BasePaginationProps<T>): JSX.Element => {
   const [currentPage, setCurrentPage] = useState(page);
 
@@ -86,7 +88,11 @@ const BasePagination = <T,>({
               <div
                 key={page}
                 className={`cursor-pointer text-lg ${
-                  currentPage === page ? "text-coral font-black" : ""
+                  currentPage === page
+                    ? "text-coral font-black"
+                    : pagesWithErrors.has(page)
+                      ? "font-semibold text-red-500"
+                      : ""
                 }`}
                 onClick={() => changePage(page)}
               >

--- a/src/components/TDViewer/base/DoubleSwapButton.tsx
+++ b/src/components/TDViewer/base/DoubleSwapButton.tsx
@@ -18,6 +18,8 @@ interface IDoubleSwapButtonProps {
   idIcon: string;
   tooltip: { html: string; href: string };
   textLabel: string;
+  compactText: string;
+  customBreakpoints: number;
   firstDescription: string;
   firstValue: boolean;
   firsthandleOnClick: (newValue: boolean, key: string) => void;
@@ -30,6 +32,8 @@ const DoubleSwapButton: React.FC<IDoubleSwapButtonProps> = ({
   idIcon,
   tooltip,
   textLabel,
+  compactText,
+  customBreakpoints,
   firstDescription,
   firstValue,
   firsthandleOnClick,
@@ -42,7 +46,9 @@ const DoubleSwapButton: React.FC<IDoubleSwapButtonProps> = ({
       <div className="col-span-4 grid h-full w-full grid-cols-12 gap-1 rounded-md">
         <div className="col-span-4 flex items-center justify-center rounded-l-md bg-blue-500">
           <InfoIconWrapper tooltip={tooltip} id={idIcon}>
-            <h1 className="p-2 font-bold text-white">{textLabel}</h1>
+            <h1 className="p-2 font-bold text-white">
+              {customBreakpoints === 1 ? compactText : textLabel}
+            </h1>
           </InfoIconWrapper>
         </div>
         <div className="col-span-8 rounded-r-md">

--- a/src/components/TDViewer/components/EditProperties.tsx
+++ b/src/components/TDViewer/components/EditProperties.tsx
@@ -36,6 +36,7 @@ interface IValidationResults {
 
 interface IEditPropertiesProps {
   isBaseModbus: boolean;
+  customBreakpoints: number;
 }
 type ModbusThingDescription = ThingDescription & {
   properties?: Record<
@@ -232,7 +233,9 @@ const EditProperties: React.FC<IEditPropertiesProps> = (props) => {
 
   return (
     <>
-      <div className="grid grid-cols-12 gap-1 rounded-t-md bg-gray-600 px-2">
+      <div
+        className={`grid ${props.customBreakpoints === 2 ? "grid-cols-1" : "grid-cols-12"} gap-1 rounded-t-md bg-gray-600 px-2`}
+      >
         <div className="col-span-12 rounded-md bg-gray-600 px-2">
           {props.isBaseModbus ? (
             <h1 className="py-1 text-xl text-white">Group Controls</h1>
@@ -242,11 +245,9 @@ const EditProperties: React.FC<IEditPropertiesProps> = (props) => {
         </div>
         <div
           id="unitId"
-          className={`col-span-4 px-2 ${
-            validateModbusProperties.unitID ? "h-16" : "h-full"
-          }`}
+          className={`${props.customBreakpoints === 2 ? "col-span-full mb-4" : "col-span-4"} flex flex-col px-2`}
         >
-          {validateModbusProperties.unitID ? (
+          <div className="min-h-[64px]">
             <SingleIncrementButton
               idIcon="unitId"
               textLabel="Unit ID"
@@ -256,37 +257,23 @@ const EditProperties: React.FC<IEditPropertiesProps> = (props) => {
               tooltip={getUniIdTooltipContent()}
               valueButton={unitId}
             />
-          ) : (
-            <>
-              <div className="flex h-full flex-col">
-                <div className="flex-grow">
-                  <SingleIncrementButton
-                    idIcon="unitId"
-                    textLabel="Unit ID"
-                    onUpdateIncrement={handleUnitIdUpdate}
-                    inferiorLimit={0}
-                    superiorLimit={255}
-                    tooltip={getUniIdTooltipContent()}
-                    valueButton={unitId}
-                  />
-                </div>
-                <div className="rounded-md p-1 text-center">
-                  <h1 className="rounded-md border-2 border-red-500 p-1 font-bold text-red-600">
-                    Different unit id is detected on different affordances.
-                    Clicking + or - will set all to the same value
-                  </h1>
-                </div>
-              </div>
-            </>
+          </div>
+
+          {!validateModbusProperties.unitID && (
+            <div className="rounded-md text-center">
+              <h1 className="rounded-md border-2 border-red-500 p-1 font-bold text-red-600">
+                Different unit id is detected on different affordances. Clicking
+                + or - will set all to the same value
+              </h1>
+            </div>
           )}
         </div>
+
         <div
           id="addressOffset"
-          className={`col-span-4 px-2 ${
-            validateModbusProperties.zeroBasedAddressing ? "h-16" : "h-full"
-          }`}
+          className={`${props.customBreakpoints === 2 ? "col-span-full mb-4" : "col-span-4"} flex flex-col px-2`}
         >
-          {validateModbusProperties.zeroBasedAddressing ? (
+          <div className="min-h-[64px]">
             <SingleSwapButton
               idIcon="addressOffset"
               tooltip={getAddressOffsetTooltipContent()}
@@ -294,50 +281,32 @@ const EditProperties: React.FC<IEditPropertiesProps> = (props) => {
               valueButton={addressOffset}
               onUpdateValue={() => handleAddressOffsetUpdate(!addressOffset)}
             />
-          ) : (
-            <>
-              <div className="flex h-full flex-col">
-                <div className="flex-grow">
-                  <SingleSwapButton
-                    idIcon="addressOffset"
-                    tooltip={getAddressOffsetTooltipContent()}
-                    textLabel="Address Offset"
-                    valueButton={addressOffset}
-                    onUpdateValue={() =>
-                      handleAddressOffsetUpdate(!addressOffset)
-                    }
-                  />
-                </div>
+          </div>
 
-                <div className="rounded-md p-1 text-center">
-                  <h1 className="rounded-md border-2 border-red-500 p-1 font-bold text-red-600">
-                    Different address offset is detected on different
-                    affordances. Clicking to swap and set all to the same value
-                  </h1>
-                </div>
-              </div>
-            </>
+          {!validateModbusProperties.zeroBasedAddressing && (
+            <div className="rounded-md text-center">
+              <h1 className="rounded-md border-2 border-red-500 p-1 font-bold text-red-600">
+                Different address offset is detected on different affordances.
+                Clicking to swap and set all to the same value
+              </h1>
+            </div>
           )}
         </div>
 
         <div
           id="endianness"
-          className={`col-span-4 px-2 ${
-            validateModbusProperties.mostSignificantByte &&
-            validateModbusProperties.mostSignificantWord
-              ? "h-16"
-              : "h-full"
-          }`}
+          className={`${props.customBreakpoints === 2 ? "col-span-full" : "col-span-4"} flex flex-col px-2`}
         >
-          {validateModbusProperties.mostSignificantByte &&
-          validateModbusProperties.mostSignificantWord ? (
+          <div className="min-h-[64px]">
             <DoubleSwapButton
               idIcon="endianness"
               tooltip={getEndiannessTooltipContent()}
               textLabel="Endianness"
+              compactText="End."
+              customBreakpoints={props.customBreakpoints}
               firstDescription="wordswap"
               firstValue={endianness.wordSwap}
-              firsthandleOnClick={(newValue, key) =>
+              firsthandleOnClick={() =>
                 handleEndiannessUpdate(!endianness.wordSwap, "wordSwap")
               }
               secondDescription="byteswap"
@@ -346,43 +315,23 @@ const EditProperties: React.FC<IEditPropertiesProps> = (props) => {
                 handleEndiannessUpdate(!endianness.byteSwap, "byteSwap")
               }
             />
-          ) : (
-            <>
-              <div className="col-span-12">
-                <DoubleSwapButton
-                  idIcon="endianness"
-                  tooltip={getEndiannessTooltipContent()}
-                  textLabel="Endianness"
-                  firstDescription="wordswap"
-                  firstValue={endianness.wordSwap}
-                  firsthandleOnClick={(newValue, key) =>
-                    handleEndiannessUpdate(!endianness.wordSwap, "wordSwap")
-                  }
-                  secondDescription="byteswap"
-                  secondValue={endianness.byteSwap}
-                  secondhandleOnClick={() =>
-                    handleEndiannessUpdate(!endianness.byteSwap, "byteSwap")
-                  }
-                />
-              </div>
-              <div className="col-span-12 p-1">
-                <div className="rounded-md text-center">
-                  <h1 className="rounded-md border-2 border-red-500 p-1 font-bold text-red-600">
-                    Different endianness (
-                    {[
-                      !validateModbusProperties.mostSignificantWord &&
-                        "wordSwap",
-                      !validateModbusProperties.mostSignificantByte &&
-                        "byteSwap",
-                    ]
-                      .filter(Boolean)
-                      .join(" and ")}
-                    ) is detected on different affordances. Clicking to swap and
-                    set all to the same value
-                  </h1>
-                </div>
-              </div>
-            </>
+          </div>
+
+          {(!validateModbusProperties.mostSignificantByte ||
+            !validateModbusProperties.mostSignificantWord) && (
+            <div className="rounded-md text-center">
+              <h1 className="rounded-md border-2 border-red-500 p-1 font-bold text-red-600">
+                Different endianness (
+                {[
+                  !validateModbusProperties.mostSignificantWord && "wordSwap",
+                  !validateModbusProperties.mostSignificantByte && "byteSwap",
+                ]
+                  .filter(Boolean)
+                  .join(" and ")}
+                ) is detected on different affordances. Clicking to swap and set
+                all to the same value
+              </h1>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/TDViewer/components/InteractionSection.tsx
+++ b/src/components/TDViewer/components/InteractionSection.tsx
@@ -546,9 +546,9 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
         <DialogTemplate
           title={editorContent.title}
           description="Modify the content using this editor"
-          onCancel={handleDialogClose}
-          onSubmit={handleDialogSubmit}
-          submitText="Save"
+          onHandleEventLeftButton={handleDialogClose}
+          onHandleEventRightButton={handleDialogSubmit}
+          rightButton="Save"
         >
           <Editor
             height="400px"

--- a/src/components/TDViewer/components/InteractionSection.tsx
+++ b/src/components/TDViewer/components/InteractionSection.tsx
@@ -33,19 +33,15 @@ import type {
   FormElementBase,
   ThingDescription,
 } from "wot-thing-description-types";
-import {
-  requestWeb,
-  extractValueByPath,
-} from "../../../services/thingsApiService";
 import { getLocalStorage } from "../../../services/localStorage";
 import ErrorDialog from "../../Dialogs/ErrorDialog";
-import JSONPointer from "jsonpointer";
 
 const SORT_ASC = "asc";
 const SORT_DESC = "desc";
 
 interface IInteractionSectionProps {
   interaction: "Properties" | "Actions" | "Events";
+  customBreakpoints?: number;
 }
 
 type InteractionKey = "properties" | "actions" | "events";
@@ -474,7 +470,9 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
   return (
     <>
       <div className="flex items-end justify-start pb-4 pt-8">
-        <div className="flex flex-grow">
+        <div
+          className={`flex ${props.customBreakpoints === 2 ? "flex-col" : "flex-grow"}`}
+        >
           <InfoIconWrapper
             tooltip={tooltipMapper[interaction]}
             id={interaction}
@@ -533,7 +531,10 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
       </div>
 
       {interaction === "properties" && hasModbusProperties(td) && (
-        <EditProperties isBaseModbus={hasModbusProperties(td)} />
+        <EditProperties
+          isBaseModbus={hasModbusProperties(td)}
+          customBreakpoints={props.customBreakpoints ?? 0}
+        />
       )}
 
       {childrenContent && (

--- a/src/components/TDViewer/components/InteractionSection.tsx
+++ b/src/components/TDViewer/components/InteractionSection.tsx
@@ -421,6 +421,7 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
           onRowClick={handleOnRowClick}
           onSendRequestClick={handleOnClickSendRequest}
           baseUrl={td.base ?? ""}
+          requestResults={{}}
         />
       );
     }

--- a/src/context/ContributeToCatalogState.tsx
+++ b/src/context/ContributeToCatalogState.tsx
@@ -1,0 +1,420 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import type { ThingDescription } from "wot-thing-description-types";
+import { getLocalStorage } from "../services/localStorage";
+
+type Validation = "VALID" | "INVALID" | "VALIDATING" | null;
+export type ActiveSection = "INSTANCE" | "GATEWAY" | "TABLE" | "SAVING_RESULTS";
+interface SectionError {
+  error: boolean;
+  message: string;
+}
+interface SettingsData {
+  northboundUrl: string;
+  southboundUrl: string;
+  pathToValue: string;
+}
+
+// Define the shape of the state
+export interface ContributionToCatalogState {
+  workflow: {
+    currentStep: number;
+    showDialog: boolean;
+    backgroundTdToSend: ThingDescription;
+  };
+  metadata: {
+    model: string;
+    author: string;
+    manufacturer: string;
+    license: string;
+    copyrightYear: string;
+    holder: string;
+    copied: boolean;
+    validation: Validation;
+    errorMessage: string;
+  };
+  interaction: {
+    activeSection: ActiveSection;
+    sectionErrors: {
+      instance: SectionError;
+      gateway: SectionError;
+      table: SectionError;
+      results: SectionError;
+    };
+    isTestingAll: boolean;
+    settingsData: SettingsData;
+    placeholderValues: Record<string, string>;
+    propertyResponseMap: Record<string, { value: string; error: string }>;
+  };
+  submission: {
+    tmCatalogEndpoint: string;
+    tmCatalogEndpointError: string;
+    repository: string;
+    repositoryError: string;
+    submitted: boolean;
+    submittedError: string;
+    id: string;
+    link: string;
+  };
+}
+
+// Initial state
+export const initialState: ContributionToCatalogState = {
+  workflow: {
+    currentStep: 1,
+    showDialog: false,
+    backgroundTdToSend: {} as ThingDescription,
+  },
+  metadata: {
+    model: "",
+    author: "",
+    manufacturer: "",
+    license: "",
+    copyrightYear: "",
+    holder: "",
+    copied: false,
+    validation: null,
+    errorMessage: "",
+  },
+  interaction: {
+    activeSection: "INSTANCE",
+    sectionErrors: {
+      instance: { error: false, message: "" },
+      gateway: { error: false, message: "" },
+      table: { error: false, message: "" },
+      results: { error: false, message: "" },
+    },
+    isTestingAll: false,
+    settingsData: {
+      northboundUrl: getLocalStorage("northbound") || "",
+      southboundUrl: getLocalStorage("southbound") || "",
+      pathToValue: getLocalStorage("valuePath") || "/",
+    },
+    placeholderValues: {},
+    propertyResponseMap: {},
+  },
+  submission: {
+    tmCatalogEndpoint: "",
+    tmCatalogEndpointError: "",
+    repository: "",
+    repositoryError: "",
+    submitted: false,
+    submittedError: "",
+    id: "",
+    link: "",
+  },
+};
+
+// Define action types
+export type ContributionToCatalogAction =
+  | { type: "SET_STEP"; payload: number }
+  | { type: "SHOW_DIALOG"; payload: boolean }
+  | { type: "SET_BACKGROUND_TD_TO_SEND"; payload: ThingDescription }
+  //
+  | { type: "SET_METADATA_MODEL"; payload: string }
+  | { type: "SET_METADATA_AUTHOR"; payload: string }
+  | { type: "SET_METADATA_MANUFACTURER"; payload: string }
+  | { type: "SET_METADATA_LICENSE"; payload: string }
+  | { type: "SET_METADATA_COPYRIGHT_YEAR"; payload: string }
+  | { type: "SET_METADATA_HOLDER"; payload: string }
+  | { type: "SET_METADATA_VALIDATION"; payload: Validation }
+  | { type: "SET_METADATA_ERROR_MESSAGE"; payload: string }
+  | { type: "SET_METADATA_COPIED"; payload: boolean }
+  | {
+      type: "INITIALIZE_METADATA";
+      payload: Partial<ContributionToCatalogState["metadata"]>;
+    }
+  //
+  | { type: "SET_INTERACTION_ACTIVE_SECTION"; payload: ActiveSection }
+  | {
+      type: "SET_INTERACTION_SECTION_ERROR";
+      section: "instance" | "gateway" | "table" | "saving_results";
+      error: boolean;
+      message: string;
+    }
+  | { type: "SET_INTERACTION_TESTING_ALL"; payload: boolean }
+  | { type: "SET_INTERACTION_SETTINGS_DATA"; payload: SettingsData }
+  | {
+      type: "UPDATE_INTERACTION_PLACEHOLDER_VALUES";
+      payload: Record<string, string>;
+    }
+  | {
+      type: "UPDATE_INTERACTION_SINGLE_PLACEHOLDER";
+      key: string;
+      value: string;
+    }
+  | {
+      type: "SET_INTERACTION_PROPERTY_RESPONSE_MAP";
+      payload: Record<string, { value: string; error: string }>;
+    }
+  //
+  | { type: "SET_SUBMISSION_TMCATALOG_ENDPOINT"; payload: string }
+  | { type: "SET_SUBMISSION_TMCATALOG_ENDPOINT_ERROR"; payload: string }
+  | { type: "SET_SUBMISSION_REPOSITORY"; payload: string }
+  | { type: "SET_SUBMISSION_REPOSITORY_ERROR"; payload: string }
+  | { type: "SET_SUBMISSION_SUBMITTED"; payload: boolean }
+  | { type: "SET_SUBMISSION_SUBMITTED_ERROR"; payload: string }
+  | { type: "SET_SUBMISSION_ID"; payload: string }
+  | { type: "SET_SUBMISSION_LINK"; payload: string }
+  //
+  | { type: "RESET_STATE" };
+
+// Reducer function
+export function contributionToCatalogReducer(
+  state: ContributionToCatalogState,
+  action: ContributionToCatalogAction
+): ContributionToCatalogState {
+  switch (action.type) {
+    case "SET_STEP":
+      return {
+        ...state,
+        workflow: {
+          ...state.workflow,
+          currentStep: action.payload,
+        },
+      };
+    case "SHOW_DIALOG":
+      return {
+        ...state,
+        workflow: {
+          ...state.workflow,
+          showDialog: action.payload,
+        },
+      };
+    case "SET_BACKGROUND_TD_TO_SEND":
+      return {
+        ...state,
+        workflow: {
+          ...state.workflow,
+          backgroundTdToSend: action.payload,
+        },
+      };
+    case "SET_METADATA_MODEL":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          model: action.payload,
+        },
+      };
+    case "SET_METADATA_AUTHOR":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          author: action.payload,
+        },
+      };
+    case "SET_METADATA_MANUFACTURER":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          manufacturer: action.payload,
+        },
+      };
+    case "SET_METADATA_LICENSE":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          license: action.payload,
+        },
+      };
+    case "SET_METADATA_COPYRIGHT_YEAR":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          copyrightYear: action.payload,
+        },
+      };
+    case "SET_METADATA_HOLDER":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          holder: action.payload,
+        },
+      };
+    case "SET_METADATA_VALIDATION":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          validation: action.payload,
+        },
+      };
+    case "SET_METADATA_ERROR_MESSAGE":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          errorMessage: action.payload,
+          validation: "INVALID",
+        },
+      };
+    case "SET_METADATA_COPIED":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          copied: action.payload,
+        },
+      };
+    case "INITIALIZE_METADATA":
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          ...action.payload,
+        },
+      };
+    //
+    case "SET_INTERACTION_ACTIVE_SECTION":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          activeSection: action.payload,
+        },
+      };
+    case "SET_INTERACTION_SECTION_ERROR":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          sectionErrors: {
+            ...state.interaction.sectionErrors,
+            [action.section]: {
+              error: action.error,
+              message: action.message,
+            },
+          },
+        },
+      };
+    case "SET_INTERACTION_TESTING_ALL":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          isTestingAll: action.payload,
+        },
+      };
+    case "SET_INTERACTION_SETTINGS_DATA":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          settingsData: action.payload,
+        },
+      };
+    case "UPDATE_INTERACTION_PLACEHOLDER_VALUES":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          placeholderValues: action.payload,
+        },
+      };
+    case "UPDATE_INTERACTION_SINGLE_PLACEHOLDER":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          placeholderValues: {
+            ...state.interaction.placeholderValues,
+            [action.key]: action.value,
+          },
+        },
+      };
+    case "SET_INTERACTION_PROPERTY_RESPONSE_MAP":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          propertyResponseMap: action.payload,
+        },
+      };
+    //
+    case "SET_SUBMISSION_TMCATALOG_ENDPOINT":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          tmCatalogEndpoint: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_TMCATALOG_ENDPOINT_ERROR":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          tmCatalogEndpointError: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_REPOSITORY":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          repository: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_REPOSITORY_ERROR":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          repositoryError: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_SUBMITTED":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          submitted: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_SUBMITTED_ERROR":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          submittedError: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_ID":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          id: action.payload,
+        },
+      };
+    case "SET_SUBMISSION_LINK":
+      return {
+        ...state,
+        submission: {
+          ...state.submission,
+          link: action.payload,
+        },
+      };
+    //
+    case "RESET_STATE":
+      return initialState;
+    default:
+      return state;
+  }
+}

--- a/src/context/GlobalState.tsx
+++ b/src/context/GlobalState.tsx
@@ -60,7 +60,6 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
       nameRepository: "",
       dynamicValues: {},
     },
-    backgroundTM: "",
   });
 
   const updateOfflineTD = (offlineTD: string) => {
@@ -144,9 +143,6 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
       contributeCatalog: contributeCatalog,
     });
   };
-  const updateBackgroundTM = (backgroundTM: string) => {
-    dispatch({ type: UPDATE_BACKGROUND_TM, backgroundTM: backgroundTM });
-  };
 
   return (
     <EdiTDorContext.Provider
@@ -161,7 +157,6 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         validationMessage: editdorState.validationMessage,
         northboundConnection: editdorState.northboundConnection,
         contributeCatalog: editdorState.contributeCatalog,
-        backgroundTM: editdorState.backgroundTM,
         updateOfflineTD,
         updateIsModified,
         setFileHandle,
@@ -174,7 +169,6 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         updateValidationMessage,
         updateNorthboundConnection,
         updateContributeCatalog,
-        updateBackgroundTM,
       }}
     >
       {children}

--- a/src/context/GlobalState.tsx
+++ b/src/context/GlobalState.tsx
@@ -26,6 +26,7 @@ export const ADD_LINKED_TD = "ADD_LINKED_TD";
 export const UPDATE_LINKED_TD = "UPDATE_LINKED_TD";
 export const UPDATE_VALIDATION_MESSAGE = "UPDATE_VALIDATION_MESSAGE";
 export const UPDATE_NORTHBOUND_CONNECTION = "UPDATE_NORTHBOUND_CONNECTION";
+export const UPDATE_CONTRIBUTE_CATALOG = "UPDATE_CONTRIBUTE_CATALOG";
 
 interface IGlobalStateProps {
   children: ReactNode;
@@ -46,6 +47,16 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
     northboundConnection: {
       message: "",
       northboundTd: {},
+    },
+    contributeCatalog: {
+      model: "",
+      author: "",
+      manufacturer: "",
+      license: "",
+      copyrightYear: "",
+      holder: "",
+      tmCatalogEndpoint: "",
+      nameRepository: "",
     },
   });
 
@@ -124,6 +135,13 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
     });
   };
 
+  const updateContributeCatalog = (contributeCatalog: IContributeCatalog) => {
+    dispatch({
+      type: UPDATE_CONTRIBUTE_CATALOG,
+      contributeCatalog: contributeCatalog,
+    });
+  };
+
   return (
     <EdiTDorContext.Provider
       value={{
@@ -136,6 +154,7 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         linkedTd: editdorState.linkedTd,
         validationMessage: editdorState.validationMessage,
         northboundConnection: editdorState.northboundConnection,
+        contributeCatalog: editdorState.contributeCatalog,
         updateOfflineTD,
         updateIsModified,
         setFileHandle,
@@ -147,6 +166,7 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         updateLinkedTd,
         updateValidationMessage,
         updateNorthboundConnection,
+        updateContributeCatalog,
       }}
     >
       {children}

--- a/src/context/GlobalState.tsx
+++ b/src/context/GlobalState.tsx
@@ -27,6 +27,7 @@ export const UPDATE_LINKED_TD = "UPDATE_LINKED_TD";
 export const UPDATE_VALIDATION_MESSAGE = "UPDATE_VALIDATION_MESSAGE";
 export const UPDATE_NORTHBOUND_CONNECTION = "UPDATE_NORTHBOUND_CONNECTION";
 export const UPDATE_CONTRIBUTE_CATALOG = "UPDATE_CONTRIBUTE_CATALOG";
+export const UPDATE_BACKGROUND_TM = "UPDATE_BACKGROUND_TM";
 
 interface IGlobalStateProps {
   children: ReactNode;
@@ -57,7 +58,9 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
       holder: "",
       tmCatalogEndpoint: "",
       nameRepository: "",
+      dynamicValues: {},
     },
+    backgroundTM: "",
   });
 
   const updateOfflineTD = (offlineTD: string) => {
@@ -141,6 +144,9 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
       contributeCatalog: contributeCatalog,
     });
   };
+  const updateBackgroundTM = (backgroundTM: string) => {
+    dispatch({ type: UPDATE_BACKGROUND_TM, backgroundTM: backgroundTM });
+  };
 
   return (
     <EdiTDorContext.Provider
@@ -155,6 +161,7 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         validationMessage: editdorState.validationMessage,
         northboundConnection: editdorState.northboundConnection,
         contributeCatalog: editdorState.contributeCatalog,
+        backgroundTM: editdorState.backgroundTM,
         updateOfflineTD,
         updateIsModified,
         setFileHandle,
@@ -167,6 +174,7 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         updateValidationMessage,
         updateNorthboundConnection,
         updateContributeCatalog,
+        updateBackgroundTM,
       }}
     >
       {children}

--- a/src/context/ediTDorContext.ts
+++ b/src/context/ediTDorContext.ts
@@ -36,7 +36,6 @@ const defaultContext: IEdiTDorContext = {
     nameRepository: "",
     dynamicValues: {},
   },
-  backgroundTM: "",
 
   updateOfflineTD: () => {},
   updateIsModified: () => {},
@@ -50,7 +49,6 @@ const defaultContext: IEdiTDorContext = {
   updateValidationMessage: () => {},
   updateNorthboundConnection: () => {},
   updateContributeCatalog: () => {},
-  updateBackgroundTM: () => {},
 };
 
 const ediTDorContext = React.createContext<IEdiTDorContext>(defaultContext);

--- a/src/context/ediTDorContext.ts
+++ b/src/context/ediTDorContext.ts
@@ -34,7 +34,9 @@ const defaultContext: IEdiTDorContext = {
     holder: "",
     tmCatalogEndpoint: "",
     nameRepository: "",
+    dynamicValues: {},
   },
+  backgroundTM: "",
 
   updateOfflineTD: () => {},
   updateIsModified: () => {},
@@ -48,6 +50,7 @@ const defaultContext: IEdiTDorContext = {
   updateValidationMessage: () => {},
   updateNorthboundConnection: () => {},
   updateContributeCatalog: () => {},
+  updateBackgroundTM: () => {},
 };
 
 const ediTDorContext = React.createContext<IEdiTDorContext>(defaultContext);

--- a/src/context/ediTDorContext.ts
+++ b/src/context/ediTDorContext.ts
@@ -25,6 +25,16 @@ const defaultContext: IEdiTDorContext = {
     message: "",
     northboundTd: {},
   },
+  contributeCatalog: {
+    model: "",
+    author: "",
+    manufacturer: "",
+    license: "",
+    copyrightYear: "",
+    holder: "",
+    tmCatalogEndpoint: "",
+    nameRepository: "",
+  },
 
   updateOfflineTD: () => {},
   updateIsModified: () => {},
@@ -37,6 +47,7 @@ const defaultContext: IEdiTDorContext = {
   updateLinkedTd: () => {},
   updateValidationMessage: () => {},
   updateNorthboundConnection: () => {},
+  updateContributeCatalog: () => {},
 };
 
 const ediTDorContext = React.createContext<IEdiTDorContext>(defaultContext);

--- a/src/context/editorReducers.ts
+++ b/src/context/editorReducers.ts
@@ -22,6 +22,7 @@ import {
   UPDATE_OFFLINE_TD,
   UPDATE_VALIDATION_MESSAGE,
   UPDATE_NORTHBOUND_CONNECTION,
+  UPDATE_CONTRIBUTE_CATALOG,
 } from "./GlobalState";
 import type {
   ThingDescription,
@@ -67,6 +68,8 @@ export const editdorReducer = (
       return updateValidationMessage(action.validationMessage, state);
     case UPDATE_NORTHBOUND_CONNECTION:
       return updateNorthboundConnection(action.northboundConnection, state);
+    case UPDATE_CONTRIBUTE_CATALOG:
+      return updateContributeCatalog(action.contributeCatalog, state);
     default:
       return state;
   }
@@ -354,4 +357,11 @@ const updateNorthboundConnection = (
   state: EditorState
 ): EditorState => {
   return { ...state, northboundConnection };
+};
+
+const updateContributeCatalog = (
+  contributeCatalog: IContributeCatalog,
+  state: EditorState
+): EditorState => {
+  return { ...state, contributeCatalog };
 };

--- a/src/context/editorReducers.ts
+++ b/src/context/editorReducers.ts
@@ -365,3 +365,9 @@ const updateContributeCatalog = (
 ): EditorState => {
   return { ...state, contributeCatalog };
 };
+const updateBackgroundTM = (
+  backgroundTM: string,
+  state: EditorState
+): EditorState => {
+  return { ...state, backgroundTM };
+};

--- a/src/context/editorReducers.ts
+++ b/src/context/editorReducers.ts
@@ -365,9 +365,3 @@ const updateContributeCatalog = (
 ): EditorState => {
   return { ...state, contributeCatalog };
 };
-const updateBackgroundTM = (
-  backgroundTM: string,
-  state: EditorState
-): EditorState => {
-  return { ...state, backgroundTM };
-};

--- a/src/services/form.ts
+++ b/src/services/form.ts
@@ -200,7 +200,15 @@ async function readPropertyWithServient(
     if (typeof val === "object" || Array.isArray(val)) {
       try {
         const key = JSONPointer.get(val, valuePath);
-        return { result: JSON.stringify(key, null, 2), err: null };
+
+        if (key === undefined) {
+          return {
+            result: JSON.stringify(val, null, 2),
+            err: null,
+          };
+        } else {
+          return { result: JSON.stringify(key, null, 2), err: null };
+        }
       } catch (e) {
         return {
           result: "",
@@ -214,7 +222,12 @@ async function readPropertyWithServient(
     return { result: JSON.stringify(val, null, 2), err: null };
   } catch (e) {
     console.debug(e);
-    return { result: "", err: e as Error };
+    return {
+      result: "",
+      err: new Error(
+        "Read property failed. Please check the hrefs on forms or the Settings section."
+      ),
+    };
   }
 }
 

--- a/src/services/operations.test.ts
+++ b/src/services/operations.test.ts
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { test, expect, describe } from "vitest";
+import { normalizeContext } from "./operations";
+import { ThingContext } from "wot-thing-description-types";
+
+describe("normalizeContext", () => {
+  test("should return array with schema when context is a valid TD context string", () => {
+    const context: ThingContext = "https://www.w3.org/2022/wot/td/v1.1";
+    const result = normalizeContext(context);
+    expect(result).toEqual([
+      "https://www.w3.org/2022/wot/td/v1.1",
+      { schema: "https://schema.org/" },
+    ]);
+  });
+
+  test("should throw error when context is an invalid string", () => {
+    const context = "invalid-context";
+    expect(() => normalizeContext(context as any)).toThrow(
+      "validation schema is wrong"
+    );
+  });
+
+  test("should return context as is when it is an object", () => {
+    // @ts-expect-error - Testing with invalid context object format
+    const context: ThingContext = { custom: "context" };
+    const result = normalizeContext(context);
+    expect(result).toEqual({ custom: "context" });
+  });
+
+  test("should return array with schema when context is an array with valid TD context string", () => {
+    const context: ThingContext = [
+      "https://www.w3.org/2022/wot/td/v1.1",
+      { custom: "context" },
+    ];
+    const result = normalizeContext(context);
+
+    expect(result).toEqual([
+      "https://www.w3.org/2022/wot/td/v1.1",
+      { custom: "context", schema: "https://schema.org/" },
+    ]);
+  });
+
+  test("should return context as is when context is an array without valid TD context string", () => {
+    // @ts-expect-error - Testing with invalid context object format
+    const context: ThingContext = [{ custom: "context" }];
+    const result = normalizeContext(context);
+    expect(result).toEqual([{ custom: "context" }]);
+  });
+
+  test("should return context as is when context is an empty array", () => {
+    const context: ThingContext = [];
+    const result = normalizeContext(context);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/services/operations.test.ts
+++ b/src/services/operations.test.ts
@@ -11,7 +11,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 import { test, expect, describe } from "vitest";
-import { normalizeContext } from "./operations";
+import {
+  normalizeContext,
+  extractPlaceholders,
+  filterAffordances,
+  processConversionTMtoTD,
+} from "./operations";
 import { ThingContext } from "wot-thing-description-types";
 
 describe("normalizeContext", () => {
@@ -62,5 +67,382 @@ describe("normalizeContext", () => {
     const context: ThingContext = [];
     const result = normalizeContext(context);
     expect(result).toEqual([]);
+  });
+});
+
+describe("extractPlaceholders", () => {
+  test("returns empty array when no placeholders are present", () => {
+    expect(extractPlaceholders("This is a test string.")).toEqual([]);
+  });
+
+  test("extracts a single placeholder", () => {
+    expect(extractPlaceholders("Hello {{name}}!")).toEqual(["name"]);
+  });
+
+  test("extracts multiple unique placeholders", () => {
+    expect(extractPlaceholders("{{foo}} and {{bar}} and {{baz}}")).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+  });
+
+  test("removes duplicate placeholders", () => {
+    expect(extractPlaceholders("{{foo}} and {{foo}}")).toEqual(["foo"]);
+  });
+
+  test("handles placeholders with spaces", () => {
+    expect(extractPlaceholders("{{ first }} and {{second}}")).toEqual([
+      " first ",
+      "second",
+    ]);
+  });
+
+  test("handles adjacent placeholders", () => {
+    expect(extractPlaceholders("{{foo}}{{bar}}")).toEqual(["foo", "bar"]);
+  });
+
+  test.skip("handles nested curly braces (should not nest)", () => {
+    expect(extractPlaceholders("{{foo{{bar}}baz}}")).toEqual(["foo{{bar"]);
+  });
+
+  test.skip("handles incomplete placeholders (no closing braces)", () => {
+    expect(extractPlaceholders("Hello {{name!")).toEqual([]);
+  });
+
+  test("handles incomplete placeholders (no opening braces)", () => {
+    expect(extractPlaceholders("Hello name}}!")).toEqual([]);
+  });
+
+  test("handles empty placeholder", () => {
+    expect(extractPlaceholders("Hello {{}}!")).toEqual([""]);
+  });
+
+  test("handles multiple empty placeholders", () => {
+    expect(extractPlaceholders("{{}} {{}}")).toEqual([""]);
+  });
+
+  test("handles placeholder at the start and end", () => {
+    expect(extractPlaceholders("{{start}} middle {{end}}")).toEqual([
+      "start",
+      "end",
+    ]);
+  });
+});
+
+describe("filterAffordances", () => {
+  const exampleAffordances = {
+    IDENT_IM0_MANUFACTURER_ID: {
+      forms: [
+        {
+          op: ["readproperty"],
+          href: "/",
+          "modbus:unitID": 12,
+          "modbus:quantity": 1,
+          "modbus:address": 2,
+          "modbus:type": "integer",
+          "modbus:entity": "HoldingRegister",
+          "modbus:zeroBasedAddressing": false,
+        },
+      ],
+      "cpcom:id": 2,
+      title: "Manufacturer ID",
+      titles: {
+        "en-US": "Manufacturer ID",
+        "de-DE": "Hersteller ID",
+        fr: "ID fabricant",
+      },
+      observable: false,
+      readOnly: true,
+      writeOnly: false,
+      type: "integer",
+      default: 42,
+    },
+    IDENT_IM0_ORDER_ID: {
+      forms: [
+        {
+          op: ["readproperty"],
+          href: "/",
+          "modbus:unitID": 12,
+          "modbus:quantity": 10,
+          "modbus:address": 3,
+          "modbus:type": "string",
+          "modbus:entity": "HoldingRegister",
+          "modbus:zeroBasedAddressing": false,
+        },
+      ],
+      "cpcom:id": 3,
+      title: "Order Number",
+      titles: {
+        "en-US": "Order Number",
+        "de-DE": "Bestellnummer",
+        fr: "Numéro de référence",
+      },
+      observable: false,
+      readOnly: true,
+      writeOnly: false,
+      type: "string",
+    },
+    IDENT_IM0_SERIAL_NUMBER: {
+      forms: [
+        {
+          op: ["readproperty"],
+          href: "/",
+          "modbus:unitID": 12,
+          "modbus:quantity": 8,
+          "modbus:address": 13,
+          "modbus:type": "string",
+          "modbus:entity": "HoldingRegister",
+          "modbus:zeroBasedAddressing": false,
+        },
+      ],
+      "cpcom:id": 4,
+      title: "Serial Number",
+      titles: {
+        "en-US": "Serial Number",
+        "de-DE": "Seriennummer",
+        fr: "Numéro de série",
+      },
+      observable: false,
+      readOnly: true,
+      writeOnly: false,
+      type: "string",
+    },
+    IDENT_IM0_HARDWARE_REVISION: {
+      forms: [
+        {
+          op: ["readproperty"],
+          href: "/",
+          "modbus:unitID": 12,
+          "modbus:quantity": 1,
+          "modbus:address": 21,
+          "modbus:type": "integer",
+          "modbus:entity": "HoldingRegister",
+          "modbus:zeroBasedAddressing": false,
+        },
+      ],
+      "cpcom:id": 5,
+      title: "Hardware Revision",
+      titles: {
+        "en-US": "Hardware Revision",
+        "de-DE": "Hardware Version",
+        fr: "Révision du matériel",
+      },
+      observable: false,
+      readOnly: true,
+      writeOnly: false,
+      type: "integer",
+      default: 0,
+    },
+  };
+
+  test("returns only the allowed affordances", () => {
+    const allowed = ["IDENT_IM0_ORDER_ID", "IDENT_IM0_SERIAL_NUMBER"];
+    const result = filterAffordances(exampleAffordances, allowed);
+    expect(Object.keys(result)).toEqual(allowed);
+    expect(result.IDENT_IM0_ORDER_ID).toEqual(
+      exampleAffordances.IDENT_IM0_ORDER_ID
+    );
+    expect(result.IDENT_IM0_SERIAL_NUMBER).toEqual(
+      exampleAffordances.IDENT_IM0_SERIAL_NUMBER
+    );
+  });
+
+  test("returns an empty object if no keys are allowed", () => {
+    const allowed: string[] = [];
+    const result = filterAffordances(exampleAffordances, allowed);
+    expect(result).toEqual({});
+  });
+
+  test("returns all affordances if all keys are allowed", () => {
+    const allowed = Object.keys(exampleAffordances);
+    const result = filterAffordances(exampleAffordances, allowed);
+    expect(result).toEqual(exampleAffordances);
+  });
+
+  test("ignores allowed keys that do not exist in the object", () => {
+    const allowed = ["IDENT_IM0_ORDER_ID", "NON_EXISTENT_KEY"];
+    const result = filterAffordances(exampleAffordances, allowed);
+    expect(Object.keys(result)).toEqual(["IDENT_IM0_ORDER_ID"]);
+    expect(result.IDENT_IM0_ORDER_ID).toEqual(
+      exampleAffordances.IDENT_IM0_ORDER_ID
+    );
+    expect(result).not.toHaveProperty("NON_EXISTENT_KEY");
+  });
+
+  test("returns an empty object if input object is empty", () => {
+    const allowed = ["IDENT_IM0_ORDER_ID"];
+    const result = filterAffordances({}, allowed);
+    expect(result).toEqual({});
+  });
+});
+
+describe("processConversionTMtoTD", () => {
+  test("correctly replaces string placeholders", () => {
+    const tmContent = `{
+      "title": "{{title}}",
+      "description": "{{description}}",
+      "properties": { "prop1": { "type": "string" } }
+    }`;
+
+    const result = processConversionTMtoTD(
+      tmContent,
+      { title: "Test Thing", description: "A test thing" },
+      ["prop1"],
+      [],
+      []
+    );
+
+    expect(result.title).toBe("Test Thing");
+    expect(result.description).toBe("A test thing");
+  });
+
+  test("correctly replaces numeric placeholders", () => {
+    const tmContent = `{
+      "id": "urn:test:{{id}}",
+      "version": {{version}},
+      "properties": { "temp": { "type": "number", "minimum": {{min}} } }
+    }`;
+
+    const result = processConversionTMtoTD(
+      tmContent,
+      { id: "123", version: "1", min: "0" },
+      ["temp"],
+      [],
+      []
+    );
+
+    expect(result.id).toBe("urn:test:123");
+    expect(result.version).toBe(1); // Number, not string
+    expect(result.properties.temp.minimum).toBe(0); // Number, not string
+  });
+
+  test("correctly filters properties", () => {
+    const tmContent = `{
+      "properties": {
+        "prop1": { "type": "string" },
+        "prop2": { "type": "number" },
+        "prop3": { "type": "boolean" }
+      }
+    }`;
+
+    const result = processConversionTMtoTD(
+      tmContent,
+      {},
+      ["prop1", "prop3"],
+      [],
+      []
+    );
+
+    expect(Object.keys(result.properties)).toHaveLength(2);
+    expect(result.properties).toHaveProperty("prop1");
+    expect(result.properties).toHaveProperty("prop3");
+    expect(result.properties).not.toHaveProperty("prop2");
+  });
+
+  test("correctly filters actions", () => {
+    const tmContent = `{
+      "actions": {
+        "action1": {},
+        "action2": {},
+        "action3": {}
+      }
+    }`;
+
+    const result = processConversionTMtoTD(tmContent, {}, [], ["action2"], []);
+
+    expect(Object.keys(result.actions)).toHaveLength(1);
+    expect(result.actions).toHaveProperty("action2");
+    expect(result.actions).not.toHaveProperty("action1");
+    expect(result.actions).not.toHaveProperty("action3");
+  });
+
+  test("correctly filters events", () => {
+    const tmContent = `{
+      "events": {
+        "event1": {},
+        "event2": {},
+        "event3": {}
+      }
+    }`;
+
+    const result = processConversionTMtoTD(
+      tmContent,
+      {},
+      [],
+      [],
+      ["event1", "event3"]
+    );
+
+    expect(Object.keys(result.events)).toHaveLength(2);
+    expect(result.events).toHaveProperty("event1");
+    expect(result.events).toHaveProperty("event3");
+    expect(result.events).not.toHaveProperty("event2");
+  });
+
+  test("removes TM-specific fields", () => {
+    const tmContent = `{
+      "@type": "tm:ThingModel",
+      "tm:required": ["#properties/prop1"],
+      "properties": { "prop1": {} }
+    }`;
+
+    const result = processConversionTMtoTD(tmContent, {}, ["prop1"], [], []);
+
+    expect(result).not.toHaveProperty("@type");
+    expect(result).not.toHaveProperty("tm:required");
+  });
+  test("handles complex TM to TD conversion", () => {
+    const tmContent = `{
+      "@type": "tm:ThingModel",
+      "title": "{{modelName}}",
+      "version": {{version}},
+      "tm:required": ["#properties/required1"],
+      "properties": {
+        "required1": { "type": "string" },
+        "optional1": { "type": "number" },
+        "optional2": { "type": "boolean" }
+      },
+      "actions": {
+        "action1": {},
+        "action2": {}
+      },
+      "events": {
+        "event1": {},
+        "event2": {}
+      }
+    }`;
+
+    const result = processConversionTMtoTD(
+      tmContent,
+      { modelName: "Test Model", version: "2.1" },
+      ["required1", "optional2"],
+      ["action1"],
+      ["event2"]
+    );
+
+    // Check basic properties
+    expect(result.title).toBe("Test Model");
+    expect(result.version).toBe(2.1);
+
+    // Check TM fields removed
+    expect(result).not.toHaveProperty("@type");
+    expect(result).not.toHaveProperty("tm:required");
+
+    // Check filtered properties
+    expect(Object.keys(result.properties)).toHaveLength(2);
+    expect(result.properties).toHaveProperty("required1");
+    expect(result.properties).toHaveProperty("optional2");
+    expect(result.properties).not.toHaveProperty("optional1");
+
+    // Check filtered actions
+    expect(Object.keys(result.actions)).toHaveLength(1);
+    expect(result.actions).toHaveProperty("action1");
+    expect(result.actions).not.toHaveProperty("action2");
+
+    // Check filtered events
+    expect(Object.keys(result.events)).toHaveLength(1);
+    expect(result.events).toHaveProperty("event2");
+    expect(result.events).not.toHaveProperty("event1");
   });
 });

--- a/src/services/operations.ts
+++ b/src/services/operations.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import type { ThingContext } from "wot-thing-description-types";
+
+export function normalizeContext(context: ThingContext): any {
+  const TD_CONTEXTS = [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    "https://www.w3.org/2019/wot/td/v1",
+  ];
+  const SCHEMA_URL = "https://schema.org/";
+
+  if (typeof context === "string") {
+    if (TD_CONTEXTS.includes(context)) {
+      return [context, { schema: SCHEMA_URL }];
+    }
+    throw new Error("validation schema is wrong");
+  }
+  if (Array.isArray(context)) {
+    const tdContexts = context.filter(
+      (item) => typeof item === "string" && TD_CONTEXTS.includes(item)
+    );
+    const objContexts = context.filter(
+      (item) => typeof item === "object" && item !== null
+    ) as Record<string, any>[];
+
+    if (tdContexts.length > 0) {
+      if (objContexts.length > 0) {
+        const newObjContexts = objContexts.map((obj) =>
+          "schema" in obj ? obj : { schema: SCHEMA_URL, ...obj }
+        );
+        return [...tdContexts, ...newObjContexts];
+      } else {
+        return [...tdContexts, { schema: SCHEMA_URL }];
+      }
+    }
+    return context;
+  }
+  return context;
+}

--- a/src/services/operations.ts
+++ b/src/services/operations.ts
@@ -109,22 +109,7 @@ export function processConversionTMtoTD(
   actions: string[],
   events: string[]
 ) {
-  // Apply placeholder values
-  let processedContent = tmContent;
-
-  Object.entries(placeholderValues).forEach(([key, value]) => {
-    const numValue = Number(value);
-    if (!isNaN(numValue)) {
-      processedContent = processedContent
-        .replace(new RegExp(`"{{${key}}}"`, "g"), value)
-        .replace(new RegExp(`{{${key}}}`, "g"), value);
-    } else {
-      processedContent = processedContent.replace(
-        new RegExp(`{{${key}}}`, "g"),
-        value
-      );
-    }
-  });
+  const processedContent = replacePlaceholders(tmContent, placeholderValues);
 
   try {
     const parsed = JSON.parse(processedContent);
@@ -148,4 +133,33 @@ export function processConversionTMtoTD(
     console.error("Error processing TM:", error);
     return null;
   }
+}
+
+/**
+ * Replaces placeholder variables in a string with their values
+ * @param content The string containing placeholders in format {{placeholderName}}
+ * @param placeholderValues Object mapping placeholder names to their values
+ * @returns String with all placeholders replaced with their values
+ */
+export function replacePlaceholders(
+  content: string,
+  placeholderValues: Record<string, string>
+): string {
+  let processedContent = content;
+
+  Object.entries(placeholderValues).forEach(([key, value]) => {
+    const numValue = Number(value);
+    if (!isNaN(numValue)) {
+      processedContent = processedContent
+        .replace(new RegExp(`"{{${key}}}"`, "g"), value)
+        .replace(new RegExp(`{{${key}}}`, "g"), value);
+    } else {
+      processedContent = processedContent.replace(
+        new RegExp(`{{${key}}}`, "g"),
+        value
+      );
+    }
+  });
+
+  return processedContent;
 }

--- a/src/services/thingsApiService.test.ts
+++ b/src/services/thingsApiService.test.ts
@@ -1,0 +1,505 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  requestWeb,
+  isSuccessResponse,
+  handleHttpRequest,
+  fetchNorthboundTD,
+  extractValueByPath,
+  buildUrlWithParams,
+} from "./thingsApiService";
+import { getLocalStorage } from "./localStorage";
+import { HttpResponse, HttpSuccessResponse } from "types/global";
+
+// Mock dependencies
+vi.mock("./localStorage", () => ({
+  getLocalStorage: vi.fn(),
+}));
+
+vi.mock("../utils/strings", () => ({
+  ensureTrailingSlash: vi.fn((url) => (url ? `${url}/` : "")),
+}));
+
+// Setup global fetch mock
+const originalFetch = global.fetch;
+
+describe("isSuccessResponse", () => {
+  const mockResponseObject = new Response(
+    JSON.stringify({ name: "Thing1", value: 42 }),
+    {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  const mockReponseObjectError = new Response(
+    JSON.stringify({ error: "Not Found" }),
+    {
+      status: 404,
+      statusText: "Not Found",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  test("should return true when response has data and status properties", () => {
+    const response: HttpSuccessResponse = {
+      data: mockResponseObject,
+      headers: "",
+      status: 200,
+    };
+
+    expect(isSuccessResponse(response)).toBe(true);
+  });
+
+  test("should return false when response is missing data or status properties", () => {
+    const response1 = { status: 200 };
+    const response2 = { data: {} };
+    const response3 = { message: "Error", reason: "Bad Request" };
+    // @ts-expect-error Testing invalid shapes
+    expect(isSuccessResponse(response1)).toBe(false);
+    // @ts-expect-error Testing invalid shapes
+    expect(isSuccessResponse(response2)).toBe(false);
+    expect(isSuccessResponse(response3)).toBe(false);
+    // @ts-expect-error Testing invalid shapes
+    expect(isSuccessResponse(mockReponseObjectError)).toBe(false);
+  });
+});
+// TODO
+describe.skip("requestWeb", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  test("should call fetch with correct parameters for GET request", async () => {
+    const mockFetchResponse = { ok: true };
+    (global.fetch as any).mockResolvedValue(mockFetchResponse);
+
+    await requestWeb("https://example.com/api");
+
+    expect(global.fetch).toHaveBeenCalledWith("https://example.com/api", {
+      method: "GET",
+      body: undefined,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  test("should call fetch with correct parameters for POST request with body", async () => {
+    const mockFetchResponse = { ok: true };
+    (global.fetch as any).mockResolvedValue(mockFetchResponse);
+
+    const body = JSON.stringify({ name: "test" });
+    await requestWeb("https://example.com/api", "POST", body);
+
+    expect(global.fetch).toHaveBeenCalledWith("https://example.com/api", {
+      method: "POST",
+      body,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  test("should append query parameters to URL when provided", async () => {
+    const mockFetchResponse = { ok: true };
+    (global.fetch as any).mockResolvedValue(mockFetchResponse);
+
+    await requestWeb("https://example.com/api", "GET", undefined, {
+      queryParams: { page: 1, filter: "active", enabled: true },
+    });
+
+    // The URL in the call should include the query parameters
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /https:\/\/example\.com\/api\?page=1&filter=active&enabled=true/
+      ),
+      expect.anything()
+    );
+  });
+
+  test("should merge custom headers with default Content-Type header", async () => {
+    const mockFetchResponse = { ok: true };
+    (global.fetch as any).mockResolvedValue(mockFetchResponse);
+
+    await requestWeb("https://example.com/api", "GET", undefined, {
+      headers: { Authorization: "Bearer token123" },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("https://example.com/api", {
+      method: "GET",
+      body: undefined,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token123",
+      },
+    });
+  });
+});
+// TODO
+describe.skip("handleHttpRequest", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  test("should return a success response when fetch is successful", async () => {
+    const mockResponseData = { result: "success" };
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockResponseData),
+      headers: new Headers(),
+    };
+
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    const result = await handleHttpRequest("https://example.com/api");
+
+    expect(isSuccessResponse(result)).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.data).toBe(mockResponse);
+  });
+
+  test("should return an error response when fetch fails with HTTP error status", async () => {
+    const mockErrorData = { error: "Not Found" };
+    const mockResponse = {
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve(mockErrorData),
+    };
+
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    const result = await handleHttpRequest("https://example.com/api");
+
+    expect(isSuccessResponse(result)).toBe(false);
+    expect(result.message).toContain("Not Found");
+    expect(result.reason).toBe("Not Found");
+  });
+
+  test("should handle network errors during fetch", async () => {
+    (global.fetch as any).mockRejectedValue(new Error("Network error"));
+
+    const result = await handleHttpRequest("https://example.com/api");
+
+    expect(isSuccessResponse(result)).toBe(false);
+    expect(result.message).toBe("Network error");
+  });
+
+  test("should handle JSON parsing errors in error responses", async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error("Invalid JSON")),
+    };
+
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    const result = await handleHttpRequest("https://example.com/api");
+
+    expect(isSuccessResponse(result)).toBe(false);
+    expect(result.message).toContain("Internal Server Error");
+  });
+});
+// TODO
+describe.skip("fetchNorthboundTD", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test("should fetch and return Thing Description when northbound URL is configured", async () => {
+    const tdId = "thing123";
+    const mockTD = {
+      "@context": "https://www.w3.org/2019/wot/td/v1",
+      id: "thing123",
+      title: "Test Thing",
+    };
+
+    // Mock the localStorage function
+    (getLocalStorage as jest.Mock).mockReturnValue(
+      "https://northbound.example.com"
+    );
+
+    // Mock successful response
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockTD),
+      headers: new Headers(),
+    };
+
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    const result = await fetchNorthboundTD(tdId);
+
+    expect(result.message).toBe("Northbound TD available");
+    expect(result.data).toEqual(mockTD);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("https://northbound.example.com/thing123"),
+      expect.anything()
+    );
+  });
+
+  test("should return error message when northbound URL is not configured", async () => {
+    (getLocalStorage as jest.Mock).mockReturnValue("");
+
+    const result = await fetchNorthboundTD("thing123");
+
+    expect(result.message).toBe("No northbound URL configured in settings");
+    expect(result.data).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("should handle HTTP error when fetching TD", async () => {
+    (getLocalStorage as jest.Mock).mockReturnValue(
+      "https://northbound.example.com"
+    );
+
+    const mockErrorResponse = {
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: "Not Found" }),
+    };
+
+    (global.fetch as any).mockResolvedValue(mockErrorResponse);
+
+    const result = await fetchNorthboundTD("thing123");
+
+    expect(result.message).toContain("Not Found");
+    expect(result.data).toBeNull();
+  });
+
+  test("should handle JSON parsing errors", async () => {
+    (getLocalStorage as jest.Mock).mockReturnValue(
+      "https://northbound.example.com"
+    );
+
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error("Invalid JSON")),
+      headers: new Headers(),
+    };
+
+    (global.fetch as any).mockResolvedValue(mockResponse);
+
+    const result = await fetchNorthboundTD("thing123");
+
+    expect(result.message).toBe("Failed to parse northbound TD");
+    expect(result.data).toBeNull();
+  });
+});
+
+describe("extractValueByPath", () => {
+  test('should return stringified object when path is empty or "/"', () => {
+    const responseData = { value: 42, status: "ok" };
+
+    expect(extractValueByPath(responseData)).toBe(JSON.stringify(responseData));
+    expect(extractValueByPath(responseData, "/")).toBe(
+      JSON.stringify(responseData)
+    );
+  });
+
+  test('should extract single-level property when path is "/propertyName"', () => {
+    const responseData = { value: 42, status: "ok" };
+
+    expect(extractValueByPath(responseData, "/value")).toBe("42");
+    expect(extractValueByPath(responseData, "/status")).toBe("ok");
+  });
+
+  test('should extract nested property when path is "/path/to/property"', () => {
+    const responseData = {
+      sensor: {
+        temperature: {
+          value: 22.5,
+          unit: "celsius",
+        },
+      },
+    };
+
+    expect(extractValueByPath(responseData, "/sensor/temperature/value")).toBe(
+      "22.5"
+    );
+    expect(extractValueByPath(responseData, "/sensor/temperature/unit")).toBe(
+      "celsius"
+    );
+  });
+
+  test("should return stringified object when property does not exist", () => {
+    const responseData = { value: 42 };
+
+    expect(extractValueByPath(responseData, "/nonexistent")).toBe(
+      JSON.stringify(responseData)
+    );
+    expect(extractValueByPath(responseData, "/path/to/nowhere")).toBe(
+      JSON.stringify(responseData)
+    );
+  });
+
+  test("should handle undefined or null values in the path", () => {
+    const responseData = {
+      a: {
+        b: null,
+        c: undefined,
+      },
+    };
+
+    expect(extractValueByPath(responseData, "/a/b/something")).toBe(
+      JSON.stringify(responseData)
+    );
+    expect(extractValueByPath(responseData, "/a/c/something")).toBe(
+      JSON.stringify(responseData)
+    );
+  });
+});
+
+describe("buildUrlWithParams", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: {
+        ...originalLocation,
+        origin: "https://example.com",
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  test("should return the endpoint unchanged when queryParams is not provided", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint);
+    expect(result).toBe(endpoint);
+  });
+
+  test("should return the endpoint unchanged when queryParams is an empty object", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, {});
+    expect(result).toBe(endpoint);
+  });
+
+  test("should append a single string parameter to the URL", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, { name: "device1" });
+    expect(result).toBe("https://api.example.com/things?name=device1");
+  });
+
+  test("should append a single number parameter to the URL", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, { id: 123 });
+    expect(result).toBe("https://api.example.com/things?id=123");
+  });
+
+  test("should append a single boolean parameter to the URL", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, { active: true });
+    expect(result).toBe("https://api.example.com/things?active=true");
+  });
+
+  test("should append multiple parameters to the URL", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, {
+      name: "device1",
+      id: 123,
+      active: true,
+    });
+    expect(result).toBe(
+      "https://api.example.com/things?name=device1&id=123&active=true"
+    );
+  });
+
+  test("should properly encode special characters in parameter values", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, {
+      query: "search term with spaces",
+      filter: "category=sensors&type=temperature",
+    });
+    // RFC3986 specifies spaces should be encoded as %20, but encodeURIComponent encodes them as +
+    // So we normalize the output for the test
+    const normalizedResult = result.replace(/\+/g, "%20");
+    // plus sign is used by URLSearchParams class
+    expect(normalizedResult).toBe(
+      "https://api.example.com/things?query=search%20term%20with%20spaces&filter=category%3Dsensors%26type%3Dtemperature"
+    );
+  });
+
+  test("should handle URLs that already have query parameters", () => {
+    const endpoint = "https://api.example.com/things?existing=param";
+    const result = buildUrlWithParams(endpoint, { new: "parameter" });
+    expect(result).toBe(
+      "https://api.example.com/things?existing=param&new=parameter"
+    );
+  });
+
+  test("should handle relative URLs by using window.location.origin", () => {
+    const endpoint = "/api/things";
+    const result = buildUrlWithParams(endpoint, { id: 123 });
+    expect(result).toBe("https://example.com/api/things?id=123");
+  });
+
+  test("should handle falsy values correctly (except undefined and null)", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, {
+      zero: 0,
+      empty: "",
+      falseVal: false,
+    });
+    expect(result).toBe(
+      "https://api.example.com/things?zero=0&empty=&falseVal=false"
+    );
+  });
+
+  test("should handle null and undefined values in queryParams", () => {
+    const endpoint = "https://api.example.com/things";
+    const result = buildUrlWithParams(endpoint, {
+      nullVal: null as any,
+      undefinedVal: undefined as any,
+      validVal: "data",
+    });
+
+    // Only the valid parameter should be appended
+    expect(result).toBe(
+      "https://api.example.com/things?nullVal=null&undefinedVal=undefined&validVal=data"
+    );
+  });
+});

--- a/src/services/thingsApiService.ts
+++ b/src/services/thingsApiService.ts
@@ -114,6 +114,7 @@ const handleHttpRequest = async (
   }
 };
 
+/** @internal */
 const buildUrlWithParams = (
   endpoint: string,
   queryParams?: Record<string, string | number | boolean>
@@ -235,4 +236,5 @@ export {
   handleHttpRequest,
   fetchNorthboundTD,
   extractValueByPath,
+  buildUrlWithParams,
 };

--- a/src/services/thingsApiService.ts
+++ b/src/services/thingsApiService.ts
@@ -37,6 +37,7 @@ const handleHttpRequest = async (
   const errorDescription: HttpErrorResponse = {
     message: "",
     reason: "",
+    status: 0,
   };
 
   try {
@@ -56,7 +57,7 @@ const handleHttpRequest = async (
           errorDescription.reason = errorData.error;
         }
       } catch (error) {}
-
+      errorDescription.status = response.status;
       switch (response.status) {
         case 301:
           throw new Error(`Monitors for the property: ${errorMessage}`);
@@ -108,6 +109,7 @@ const handleHttpRequest = async (
     const errorResponse: HttpErrorResponse = {
       message: typedError.message,
       reason: errorDescription.reason,
+      status: errorDescription.status,
     };
 
     return errorResponse;

--- a/src/types/context.d.ts
+++ b/src/types/context.d.ts
@@ -11,7 +11,6 @@ interface IEdiTDorContext {
   validationMessage?: any;
   northboundConnection: INorthboundConnection;
   contributeCatalog: IContributeCatalog;
-  backgroundTM: string;
 
   // Callback functions
   updateOfflineTD: (td: string) => void;
@@ -33,8 +32,6 @@ interface IEdiTDorContext {
     northboundConnection: INorthboundConnection
   ) => void;
   updateContributeCatalog: (contributeCatalog: IContributeCatalog) => void;
-  // Generating a background Thing Model
-  updateBackgroundTM: (backgroundTM: string) => void;
 }
 
 interface INorthboundConnection {
@@ -68,7 +65,6 @@ type EditorState = Omit<
   | "updateValidationMessage"
   | "updateNorthboundConnection"
   | "updateContributeCatalog"
-  | "updateBackgroundTM"
 >;
 
 type Action =
@@ -104,5 +100,4 @@ type Action =
   | {
       type: "UPDATE_CONTRIBUTE_CATALOG";
       contributeCatalog: IContributeCatalog;
-    }
-  | { type: "UPDATE_BACKGROUND_TM"; backgroundTM: string };
+    };

--- a/src/types/context.d.ts
+++ b/src/types/context.d.ts
@@ -10,6 +10,7 @@ interface IEdiTDorContext {
   linkedTd: Record<string, any> | undefined;
   validationMessage?: any;
   northboundConnection: INorthboundConnection;
+  contributeCatalog: IContributeCatalog;
 
   // Callback functions
   updateOfflineTD: (td: string) => void;
@@ -30,11 +31,23 @@ interface IEdiTDorContext {
   updateNorthboundConnection: (
     northboundConnection: INorthboundConnection
   ) => void;
+  updateContributeCatalog: (contributeCatalog: IContributeCatalog) => void;
 }
 
 interface INorthboundConnection {
   message: string;
   northboundTd: ThingDescription | {};
+}
+
+interface IContributeCatalog {
+  model: string;
+  author: string;
+  manufacturer: string;
+  license: string;
+  copyrightYear: string;
+  holder: string;
+  tmCatalogEndpoint: string;
+  nameRepository: string;
 }
 
 type EditorState = Omit<
@@ -50,6 +63,7 @@ type EditorState = Omit<
   | "updateLinkedTd"
   | "updateValidationMessage"
   | "updateNorthboundConnection"
+  | "updateContributeCatalog"
 >;
 
 type Action =
@@ -81,4 +95,8 @@ type Action =
   | {
       type: "UPDATE_NORTHBOUND_CONNECTION";
       northboundConnection: INorthboundConnection;
+    }
+  | {
+      type: "UPDATE_CONTRIBUTE_CATALOG";
+      contributeCatalog: IContributeCatalog;
     };

--- a/src/types/context.d.ts
+++ b/src/types/context.d.ts
@@ -11,6 +11,7 @@ interface IEdiTDorContext {
   validationMessage?: any;
   northboundConnection: INorthboundConnection;
   contributeCatalog: IContributeCatalog;
+  backgroundTM: string;
 
   // Callback functions
   updateOfflineTD: (td: string) => void;
@@ -32,6 +33,8 @@ interface IEdiTDorContext {
     northboundConnection: INorthboundConnection
   ) => void;
   updateContributeCatalog: (contributeCatalog: IContributeCatalog) => void;
+  // Generating a background Thing Model
+  updateBackgroundTM: (backgroundTM: string) => void;
 }
 
 interface INorthboundConnection {
@@ -48,6 +51,7 @@ interface IContributeCatalog {
   holder: string;
   tmCatalogEndpoint: string;
   nameRepository: string;
+  dynamicValues: Record<string, string>;
 }
 
 type EditorState = Omit<
@@ -64,6 +68,7 @@ type EditorState = Omit<
   | "updateValidationMessage"
   | "updateNorthboundConnection"
   | "updateContributeCatalog"
+  | "updateBackgroundTM"
 >;
 
 type Action =
@@ -99,4 +104,5 @@ type Action =
   | {
       type: "UPDATE_CONTRIBUTE_CATALOG";
       contributeCatalog: IContributeCatalog;
-    };
+    }
+  | { type: "UPDATE_BACKGROUND_TM"; backgroundTM: string };

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -39,6 +39,7 @@ export interface HttpSuccessResponse {
 export interface HttpErrorResponse {
   message: string;
   reason: string;
+  status?: number;
 }
 
 export type HttpResponse = HttpSuccessResponse | HttpErrorResponse;
@@ -50,5 +51,3 @@ export interface ResponseDataFromNorthbound {
   timestamp?: number;
   quality?: number;
 }
-
-export type ActiveSection = "instance" | "gateway" | "table" | "savingResults";

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -50,3 +50,5 @@ export interface ResponseDataFromNorthbound {
   timestamp?: number;
   quality?: number;
 }
+
+export type ActiveSection = "instance" | "gateway" | "table" | "savingResults";

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -19,3 +19,29 @@ export const removeKeyFromObjects = (
     return rest;
   });
 };
+
+export const getErrorSummary = (array: {
+  [id: string]: { value: string; error: string };
+}): { firstError: { id: string; message: string }; errorCount: number } => {
+  let firstError = { id: "", message: "" };
+  let errorCount = 0;
+
+  for (const [id, result] of Object.entries(array)) {
+    if (result.error && result.error.length > 0) {
+      errorCount++;
+
+      if (!firstError.message) {
+        const propertyName = id.split(" - ")[0];
+        firstError = {
+          id: propertyName,
+          message: result.error,
+        };
+      }
+    }
+  }
+
+  return {
+    firstError,
+    errorCount,
+  };
+};

--- a/src/utils/parser.test.ts
+++ b/src/utils/parser.test.ts
@@ -1,0 +1,334 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { test, expect, describe } from "vitest";
+import { parseCsv, mapRowToProperty, mapCsvToProperties } from "./parser";
+import type { CsvData } from "./parser";
+
+describe("parseCsv", () => {
+  test("should parse CSV content with headers correctly", () => {
+    const csvContent = `name,type,modbus:address,modbus:entity,modbus:unitID,modbus:quantity,modbus:zeroBasedAddressing,modbus:function,modbus:mostSignificantByte,modbus:mostSignificantWord,href
+temperature,number,40001,coil,1,2,false,03,true,true,/temperature`;
+
+    const result = parseCsv(csvContent, true, ",");
+
+    expect(result).toEqual([
+      {
+        name: "temperature",
+        type: "number",
+        "modbus:address": "40001",
+        "modbus:entity": "coil",
+        "modbus:unitID": "1",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+        href: "/temperature",
+      },
+    ]);
+  });
+
+  test("should handle empty CSV content", () => {
+    expect(() => parseCsv("", true, ",")).toThrow("CSV content is empty");
+  });
+
+  test("should throw error when parsing without headers", () => {
+    const csvContent = `temperature,number,40001,coil,1,2,false,03,true,true,/temperature`;
+    expect(() => parseCsv(csvContent, false, ",")).toThrow(
+      "CSV parsing without headers is not supported"
+    );
+  });
+
+  test("should handle different separator characters", () => {
+    const csvContent = `name;type;modbus:address;modbus:entity;modbus:unitID;modbus:quantity;modbus:zeroBasedAddressing;modbus:function;modbus:mostSignificantByte;modbus:mostSignificantWord;href
+temperature;number;40001;coil;1;2;false;03;true;true;/temperature`;
+
+    const result = parseCsv(csvContent, true, ";");
+
+    expect(result[0].name).toBe("temperature");
+    expect(result[0]["modbus:entity"]).toBe("coil");
+  });
+
+  test("should ignore empty rows and trim whitespace", () => {
+    const csvContent = `name,type,modbus:address,modbus:entity,modbus:unitID,modbus:quantity,modbus:zeroBasedAddressing,modbus:function,modbus:mostSignificantByte,modbus:mostSignificantWord,href
+  temperature,number,40001,coil,1,2,false,03,true,true,/temperature
+
+  humidity,number,40003, holding, 1 , 2 ,false,03,true,true,/humidity
+  `;
+
+    const result = parseCsv(csvContent, true, ",");
+
+    expect(result.length).toBe(2);
+    expect(result[1].name).toBe("humidity");
+    expect(result[1]["modbus:entity"]).toBe("holding");
+  });
+});
+
+describe("mapRowToProperty", () => {
+  test("should correctly convert all fields", () => {
+    const row: CsvData = {
+      name: "temperature",
+      title: "Temperature",
+      description: "Room temperature",
+      type: "number",
+      minimum: "0",
+      maximum: "100",
+      unit: "celsius",
+      href: "/temperature",
+      "modbus:unitID": 1,
+      "modbus:address": "40001",
+      "modbus:quantity": "2",
+      "modbus:type": "int16",
+      "modbus:zeroBasedAddressing": "true",
+      "modbus:entity": "holding",
+      "modbus:pollingTime": "1000",
+      "modbus:function": "03",
+      "modbus:mostSignificantByte": "false",
+      "modbus:mostSignificantWord": "true",
+      "modbus:timeout": "500",
+    };
+
+    const result = mapRowToProperty(row);
+
+    expect(result).toEqual({
+      type: "number",
+      readOnly: true,
+      title: "Temperature",
+      description: "Room temperature",
+      minimum: 0,
+      maximum: 100,
+      unit: "celsius",
+      forms: [
+        {
+          op: "readproperty",
+          href: "/temperature",
+          "modbus:unitID": 1,
+          "modbus:address": 40001,
+          "modbus:quantity": 2,
+          "modbus:type": "int16",
+          "modbus:zeroBasedAddressing": true,
+          "modbus:entity": "holding",
+          "modbus:pollingTime": "1000",
+          "modbus:function": "03",
+          "modbus:mostSignificantByte": false,
+          "modbus:mostSignificantWord": true,
+          "modbus:timeout": "500",
+        },
+      ],
+    });
+  });
+
+  test("should handle missing optional fields", () => {
+    const row: CsvData = {
+      name: "temperature",
+      type: "number",
+      href: "",
+      "modbus:unitID": 1,
+      "modbus:address": "40001",
+      "modbus:quantity": "2",
+      "modbus:zeroBasedAddressing": "false",
+      "modbus:entity": "holding",
+      "modbus:function": "03",
+      "modbus:mostSignificantByte": "true",
+      "modbus:mostSignificantWord": "true",
+    };
+
+    const result = mapRowToProperty(row);
+
+    expect(result.title).toBeUndefined();
+    expect(result.description).toBeUndefined();
+    expect(result.minimum).toBeUndefined();
+    expect(result.maximum).toBeUndefined();
+    expect(result.unit).toBeUndefined();
+    expect(result.forms[0].href).toBe("/");
+    expect(result.forms[0]["modbus:pollingTime"]).toBeUndefined();
+    expect(result.forms[0]["modbus:timeout"]).toBeUndefined();
+  });
+
+  test("should apply correct boolean conversions", () => {
+    const row: CsvData = {
+      name: "temperature",
+      type: "number",
+      href: "/temperature",
+      "modbus:unitID": 1,
+      "modbus:address": "40001",
+      "modbus:quantity": "2",
+      "modbus:zeroBasedAddressing": "true",
+      "modbus:entity": "holding",
+      "modbus:function": "03",
+      "modbus:mostSignificantByte": "false",
+      "modbus:mostSignificantWord": "false",
+    };
+
+    const result = mapRowToProperty(row);
+
+    expect(result.forms[0]["modbus:zeroBasedAddressing"]).toBe(true);
+    expect(result.forms[0]["modbus:mostSignificantByte"]).toBe(false);
+    expect(result.forms[0]["modbus:mostSignificantWord"]).toBe(false);
+  });
+});
+
+describe("mapCsvToProperties", () => {
+  test("should convert multiple rows correctly", () => {
+    const data: CsvData[] = [
+      {
+        name: "temperature",
+        type: "number",
+        href: "/temperature",
+        "modbus:unitID": 1,
+        "modbus:address": "40001",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:entity": "holding",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+      },
+      {
+        name: "humidity",
+        type: "number",
+        href: "/humidity",
+        "modbus:unitID": 1,
+        "modbus:address": "40003",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:entity": "holding",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+      },
+    ];
+
+    const result = mapCsvToProperties(data);
+
+    expect(Object.keys(result)).toEqual(["temperature", "humidity"]);
+    expect(result.temperature.forms[0]["modbus:address"]).toBe(40001);
+    expect(result.humidity.forms[0]["modbus:address"]).toBe(40003);
+  });
+
+  test("should throw error when name is missing", () => {
+    const data: CsvData[] = [
+      {
+        name: "",
+        type: "number",
+        href: "/temperature",
+        "modbus:unitID": 1,
+        "modbus:address": "40001",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:entity": "holding",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+      },
+    ];
+
+    expect(() => mapCsvToProperties(data)).toThrow(
+      "Error on CSV file: Row name is required"
+    );
+  });
+
+  test("should throw error when modbus:address is missing", () => {
+    const data: CsvData[] = [
+      {
+        name: "temperature",
+        type: "number",
+        href: "/temperature",
+        "modbus:unitID": 1,
+        "modbus:address": "",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:entity": "holding",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+      },
+    ];
+
+    expect(() => mapCsvToProperties(data)).toThrow(
+      'Error on CSV file: "modbus:address" value is required for row: "temperature"'
+    );
+  });
+
+  test("should throw error when modbus:entity is missing", () => {
+    const data: CsvData[] = [
+      {
+        name: "temperature",
+        type: "number",
+        href: "/temperature",
+        "modbus:unitID": 1,
+        "modbus:address": "40001",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:entity": "",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+      },
+    ];
+
+    expect(() => mapCsvToProperties(data)).toThrow(
+      'Error on CSV file: "modbus:entity" value is required for row: "temperature"'
+    );
+  });
+
+  test("should handle empty data array", () => {
+    expect(mapCsvToProperties([])).toEqual({});
+  });
+
+  test("should handle a mix of complete and partial data", () => {
+    const data: CsvData[] = [
+      {
+        name: "temperature",
+        title: "Temperature",
+        description: "Room temperature",
+        type: "number",
+        minimum: "0",
+        maximum: "100",
+        unit: "celsius",
+        href: "/temperature",
+        "modbus:unitID": 1,
+        "modbus:address": "40001",
+        "modbus:quantity": "2",
+        "modbus:type": "int16",
+        "modbus:zeroBasedAddressing": "true",
+        "modbus:entity": "holding",
+        "modbus:pollingTime": "1000",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "false",
+        "modbus:mostSignificantWord": "true",
+        "modbus:timeout": "500",
+      },
+      {
+        name: "humidity",
+        type: "number",
+        href: "/humidity",
+        "modbus:unitID": 1,
+        "modbus:address": "40003",
+        "modbus:quantity": "2",
+        "modbus:zeroBasedAddressing": "false",
+        "modbus:entity": "holding",
+        "modbus:function": "03",
+        "modbus:mostSignificantByte": "true",
+        "modbus:mostSignificantWord": "true",
+      },
+    ];
+
+    const result = mapCsvToProperties(data);
+
+    expect(result.temperature.title).toBe("Temperature");
+    expect(result.temperature.unit).toBe("celsius");
+    expect(result.humidity.title).toBeUndefined();
+    expect(result.humidity.unit).toBeUndefined();
+  });
+});

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-type CsvData = {
+export type CsvData = {
   name: string;
   title?: string;
   description?: string;
@@ -75,6 +75,8 @@ export const parseCsv = (
   hasHeaders: boolean = true,
   character: string
 ): CsvData[] => {
+  if (csvContent === "") throw new Error("CSV content is empty");
+
   const rows = csvContent
     .split("\n")
     .map((row) => row.trim())
@@ -99,7 +101,7 @@ export const parseCsv = (
  * @param row
  * @returns
  */
-const mapRowToProperty = (row: CsvData): Property => ({
+export const mapRowToProperty = (row: CsvData): Property => ({
   ...(row.type ? { type: row.type } : {}),
   readOnly: true,
   ...(row.title ? { title: row.title } : {}),
@@ -125,9 +127,13 @@ const mapRowToProperty = (row: CsvData): Property => ({
         ? { "modbus:function": row["modbus:function"] }
         : {}),
       "modbus:mostSignificantByte":
-        Boolean(row["modbus:mostSignificantByte"]) ?? true,
+        row["modbus:mostSignificantByte"]?.toLowerCase() === "true"
+          ? true
+          : false,
       "modbus:mostSignificantWord":
-        Boolean(row["modbus:mostSignificantWord"]) ?? true,
+        row["modbus:mostSignificantWord"]?.toLowerCase() === "true"
+          ? true
+          : false,
       ...(row["modbus:timeout"]
         ? { "modbus:timeout": row["modbus:timeout"] }
         : {}),

--- a/src/utils/strings.test.ts
+++ b/src/utils/strings.test.ts
@@ -1,0 +1,171 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { test, expect, describe } from "vitest";
+import {
+  extractIndexFromId,
+  isValidUrl,
+  formatTextKey,
+  formatText,
+  capitalizeFirstLetter,
+  ensureTrailingSlash,
+  stripDoubleQuotes,
+} from "./strings";
+
+describe("extractIndexFromId", () => {
+  test("should extract index from a properly formatted ID", () => {
+    expect(extractIndexFromId("item - 0")).toBe(0);
+    expect(extractIndexFromId("item - 42")).toBe(42);
+  });
+  test("other cases", () => {
+    expect(extractIndexFromId("temperature - -5")).toBe(-5);
+    expect(extractIndexFromId("property - 1 - extra")).toBe(1);
+    expect(extractIndexFromId("item-")).toBe(NaN);
+    expect(extractIndexFromId("item")).toBe(NaN);
+    expect(Number.isNaN(extractIndexFromId("property - abc"))).toBe(true);
+    expect(extractIndexFromId("property -  5 ")).toBe(5);
+  });
+});
+
+describe("isValidUrl", () => {
+  test("should validate URLs correctly", () => {
+    expect(isValidUrl("https://example.com")).toBe(true);
+    expect(isValidUrl("http://localhost:3000")).toBe(true);
+  });
+  test("should invalidate non-HTTP URLs", () => {
+    expect(isValidUrl("ftp://example.org")).toBe(false);
+    expect(isValidUrl("not-a-url")).toBe(false);
+    expect(isValidUrl("")).toBe(false);
+  });
+});
+
+describe("formatTextKey", () => {
+  test("should format text keys correctly", () => {
+    expect(formatTextKey("property", 0)).toBe("property");
+    expect(formatTextKey("modbus:address", 0)).toBe("modbus:address");
+    expect(formatTextKey("", 0)).toBe("");
+
+    expect(formatTextKey("property", 1)).toBe("property (form 2)");
+    expect(formatTextKey("modbus:address", 2)).toBe("modbus:address (form 3)");
+    expect(formatTextKey("temperature", 9)).toBe("temperature (form 10)");
+
+    expect(formatTextKey("", 1)).toBe(" (form 2)");
+    expect(formatTextKey("", 5)).toBe(" (form 6)");
+
+    expect(formatTextKey("key-with-dashes", 1)).toBe(
+      "key-with-dashes (form 2)"
+    );
+    expect(formatTextKey("key_with_underscores", 2)).toBe(
+      "key_with_underscores (form 3)"
+    );
+    expect(formatTextKey("key.with.dots", 3)).toBe("key.with.dots (form 4)");
+
+    expect(formatTextKey("property (special)", 1)).toBe(
+      "property (special) (form 2)"
+    );
+    expect(formatTextKey("(important)", 2)).toBe("(important) (form 3)");
+
+    expect(formatTextKey("property", -1)).toBe("property (form 0)");
+    expect(formatTextKey("modbus:address", -5)).toBe(
+      "modbus:address (form -4)"
+    );
+  });
+});
+
+describe("formatText", () => {
+  test("should format text correctly", () => {
+    expect(formatText("modbus:unitID")).toBe("Unit ID");
+    expect(formatText("modbus:address")).toBe("Address");
+    expect(formatText("modbus:entity")).toBe("Entity");
+
+    expect(formatText("propName")).toBe("Property Name");
+    expect(formatText("propNameTest")).toBe("Property Name");
+
+    expect(formatText("href")).toBe("Resource");
+    expect(formatText("hrefPath")).toBe("Resource");
+
+    expect(formatText("htv:methodName")).toBe("Method");
+    expect(formatText("htv:methodNameTest")).toBe("Method");
+
+    expect(formatText("camelCase")).toBe("Camel Case");
+    expect(formatText("multipleWordsInCamelCase")).toBe(
+      "Multiple Words In Camel Case"
+    );
+    expect(formatText("singleWord")).toBe("Single Word");
+
+    expect(formatText("lowercase")).toBe("Lowercase");
+    expect(formatText("alreadyCapitalized")).toBe("Already Capitalized");
+
+    expect(formatText("modbus:mostSignificantByte")).toBe(
+      "Most Significant Byte"
+    );
+    expect(formatText("modbus:unitID")).toBe("Unit ID");
+    expect(formatText("propNameExample")).toBe("Property Name");
+    expect(formatText("hrefUserProfile")).toBe("Resource");
+
+    expect(formatText("")).toBe("");
+
+    expect(formatText("Normal text")).toBe("Normal text");
+    expect(formatText("Already Capitalized")).toBe("Already Capitalized");
+
+    expect(formatText("temperature2Reading")).toBe("Temperature2Reading");
+    expect(formatText("modbus:register3Value")).toBe("Register3Value");
+  });
+});
+
+describe("capitalizeFirstLetter", () => {
+  test("should capitalize the first letter of a string", () => {
+    expect(capitalizeFirstLetter("hello")).toBe("Hello");
+    expect(capitalizeFirstLetter("world")).toBe("World");
+  });
+
+  test("should handle already capitalized strings", () => {
+    expect(capitalizeFirstLetter("already Capitalized")).toBe(
+      "Already Capitalized"
+    );
+  });
+
+  test("should handle empty strings", () => {
+    expect(capitalizeFirstLetter("")).toBe("");
+  });
+});
+
+describe("ensureTrailingSlash", () => {
+  test("should add a trailing slash if missing", () => {
+    expect(ensureTrailingSlash("https://example.com")).toBe(
+      "https://example.com/"
+    );
+  });
+
+  test("should not add a trailing slash if already present", () => {
+    expect(ensureTrailingSlash("https://example.com/")).toBe(
+      "https://example.com/"
+    );
+  });
+
+  test("should handle empty strings", () => {
+    expect(ensureTrailingSlash("")).toBe("/");
+  });
+});
+
+describe("stripDoubleQuotes", () => {
+  test("should remove double quotes from around a string", () => {
+    expect(stripDoubleQuotes('"hello"')).toBe("hello");
+    expect(stripDoubleQuotes("hello")).toBe("hello");
+    expect(stripDoubleQuotes('"hello')).toBe("hello");
+    expect(stripDoubleQuotes('hello"')).toBe("hello");
+    expect(stripDoubleQuotes('""')).toBe("");
+  });
+  test("should return an empty string for empty input", () => {
+    expect(stripDoubleQuotes("")).toBe("");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,7 +69,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    "stripInternal": true /* Disable emitting declarations that have '@internal' in their JSDoc comments. */,
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": [
       "./src/types",
+      "./node_modules/@types",
       "./node_modules/@wot-thing-description-types",
       "./node_modules/wot-typescript-definitions"
     ] /* Specify multiple folders that act like './node_modules/@types'. */,
@@ -109,7 +110,7 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "src/**/*",
+    "src/**/*.ts",
     "src/types/*.d.ts",
     "node_modules/wot-typescript-definitions/*",
     "node_modules/wot-thing-description-types/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,7 +452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.5":
+"@babel/runtime@npm:^7.12.5":
   version: 7.28.3
   resolution: "@babel/runtime@npm:7.28.3"
   checksum: 10c0/b360f82c2c5114f2a062d4d143d7b4ec690094764853937110585a9497977aed66c102166d0e404766c274e02a50ffb8f6d77fef7251ecf3f607f0e03e6397bc
@@ -2610,7 +2610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.6, classnames@npm:^2.3.0":
+"classnames@npm:^2.3.0":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -2923,15 +2923,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-helpers@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "dom-helpers@npm:3.4.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.1.2"
-  checksum: 10c0/1d2d3e4eadac2c4f4c8c7470a737ab32b7ec28237c4d094ea967ec3184168fd12452196fcc424a5d7860b6176117301aeaecba39467bf1a6e8492a8e5c9639d1
-  languageName: node
-  linkType: hard
-
 "dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -2997,8 +2988,8 @@ __metadata:
     react-feather: "npm:^2.0.10"
     react-icons: "npm:^5.2.1"
     react-scan: "npm:^0.4.3"
-    react-step-progress-bar: "npm:^1.0.3"
     react-tooltip: "npm:^5.26.4"
+    tailwind-merge: "npm:^3.3.1"
     tailwindcss: "npm:^3.4.7"
     typescript: "npm:^5.0.0"
     vite: "npm:^5.2.0"
@@ -4234,15 +4225,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.4":
-  version: 2.2.4
-  resolution: "invariant@npm:2.2.4"
-  dependencies:
-    loose-envify: "npm:^1.0.0"
-  checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
-  languageName: node
-  linkType: hard
-
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -4878,7 +4860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -5857,7 +5839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -5988,13 +5970,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-lifecycles-compat@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "react-lifecycles-compat@npm:3.0.4"
-  checksum: 10c0/1d0df3c85af79df720524780f00c064d53a9dd1899d785eddb7264b378026979acbddb58a4b7e06e7d0d12aa1494fd5754562ee55d32907b15601068dae82c27
-  languageName: node
-  linkType: hard
-
 "react-refresh@npm:^0.17.0":
   version: 0.17.0
   resolution: "react-refresh@npm:0.17.0"
@@ -6049,19 +6024,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-step-progress-bar@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "react-step-progress-bar@npm:1.0.3"
-  dependencies:
-    classnames: "npm:^2.2.6"
-    invariant: "npm:^2.2.4"
-    react-transition-group: "npm:^2.4.0"
-  peerDependencies:
-    react: ">=15.0.0"
-  checksum: 10c0/d1005794f796235486bf3c70dbb9e64e5e1232fc23494c0938b25f5a03e5ca5c794901c06bcc2c4af55593ff9d6e2d0fe80e6008ef951b90dc9ca284892b1005
-  languageName: node
-  linkType: hard
-
 "react-tooltip@npm:^5.26.4":
   version: 5.28.1
   resolution: "react-tooltip@npm:5.28.1"
@@ -6072,21 +6034,6 @@ __metadata:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
   checksum: 10c0/5f00407b6b55421ac1e2f6398300e0ce2f8dd7c1e2983de9977e0e1435a7b91138fab19dc3f5a0c5865df80f7dfec447cef2e79b705f27cda3bc276fe677e77f
-  languageName: node
-  linkType: hard
-
-"react-transition-group@npm:^2.4.0":
-  version: 2.9.0
-  resolution: "react-transition-group@npm:2.9.0"
-  dependencies:
-    dom-helpers: "npm:^3.4.0"
-    loose-envify: "npm:^1.4.0"
-    prop-types: "npm:^15.6.2"
-    react-lifecycles-compat: "npm:^3.0.4"
-  peerDependencies:
-    react: ">=15.0.0"
-    react-dom: ">=15.0.0"
-  checksum: 10c0/df40608e9defb6873290b9f2165921f17139b8edbb2019e2de38f77477f9cbd8fdb739b20e1e04cb16a513137c80e85cf5f0fff96049a94b740d389313394476
   languageName: node
   linkType: hard
 
@@ -6999,6 +6946,13 @@ __metadata:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 10c0/dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
+  languageName: node
+  linkType: hard
+
+"tailwind-merge@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "tailwind-merge@npm:3.3.1"
+  checksum: 10c0/b84c6a78d4669fa12bf5ab8f0cdc4400a3ce0a7c006511af4af4be70bb664a27466dbe13ee9e3b31f50ddf6c51d380e8192ce0ec9effce23ca729d71a9f63818
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,6 +1818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash@npm:^4":
+  version: 4.17.20
+  resolution: "@types/lodash@npm:4.17.20"
+  checksum: 10c0/98cdd0faae22cbb8079a01a3bb65aa8f8c41143367486c1cbf5adc83f16c9272a2a5d2c1f541f61d0d73da543c16ee1d21cf2ef86cb93cd0cc0ac3bced6dd88f
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^20.17.9":
   version: 20.19.6
   resolution: "@types/node@npm:20.19.6"
@@ -2956,6 +2963,7 @@ __metadata:
     "@types/babel__core": "npm:^7"
     "@types/json-schema": "npm:^7.0.15"
     "@types/jsonpointer": "npm:^4.0.2"
+    "@types/lodash": "npm:^4"
     "@types/node": "npm:^22.13.15"
     "@types/react": "npm:^18.2.66"
     "@types/react-dom": "npm:^18.2.22"
@@ -2977,6 +2985,7 @@ __metadata:
     json-dup-key-validator: "npm:^1.0.3"
     jsonld: "npm:^8.3.2"
     jsonpointer: "npm:^5.0.1"
+    lodash: "npm:^4.17.21"
     lz-string: "npm:^1.5.0"
     monaco-editor: "npm:^0.52.2"
     postcss: "npm:^8.4.40"
@@ -2992,6 +3001,7 @@ __metadata:
     tailwind-merge: "npm:^3.3.1"
     tailwindcss: "npm:^3.4.7"
     typescript: "npm:^5.0.0"
+    uuid: "npm:^13.0.0"
     vite: "npm:^5.2.0"
     vitest: "npm:^3.2.4"
     wot-thing-description-types: "npm:1.1.0-12-March-2025"
@@ -4853,7 +4863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:~4.17.21":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.21, lodash@npm:~4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -7412,6 +7422,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "uuid@npm:13.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/950e4c18d57fef6c69675344f5700a08af21e26b9eff2bf2180427564297368c538ea11ac9fb2e6528b17fc3966a9fd2c5049361b0b63c7d654f3c550c9b3d67
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,7 +452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.5":
   version: 7.28.3
   resolution: "@babel/runtime@npm:7.28.3"
   checksum: 10c0/b360f82c2c5114f2a062d4d143d7b4ec690094764853937110585a9497977aed66c102166d0e404766c274e02a50ffb8f6d77fef7251ecf3f607f0e03e6397bc
@@ -2610,7 +2610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.3.0":
+"classnames@npm:^2.2.6, classnames@npm:^2.3.0":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -2923,6 +2923,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-helpers@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "dom-helpers@npm:3.4.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.1.2"
+  checksum: 10c0/1d2d3e4eadac2c4f4c8c7470a737ab32b7ec28237c4d094ea967ec3184168fd12452196fcc424a5d7860b6176117301aeaecba39467bf1a6e8492a8e5c9639d1
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -2988,6 +2997,7 @@ __metadata:
     react-feather: "npm:^2.0.10"
     react-icons: "npm:^5.2.1"
     react-scan: "npm:^0.4.3"
+    react-step-progress-bar: "npm:^1.0.3"
     react-tooltip: "npm:^5.26.4"
     tailwindcss: "npm:^3.4.7"
     typescript: "npm:^5.0.0"
@@ -4224,6 +4234,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"invariant@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "invariant@npm:2.2.4"
+  dependencies:
+    loose-envify: "npm:^1.0.0"
+  checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -4859,7 +4878,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -5838,7 +5857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -5969,6 +5988,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-lifecycles-compat@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "react-lifecycles-compat@npm:3.0.4"
+  checksum: 10c0/1d0df3c85af79df720524780f00c064d53a9dd1899d785eddb7264b378026979acbddb58a4b7e06e7d0d12aa1494fd5754562ee55d32907b15601068dae82c27
+  languageName: node
+  linkType: hard
+
 "react-refresh@npm:^0.17.0":
   version: 0.17.0
   resolution: "react-refresh@npm:0.17.0"
@@ -6023,6 +6049,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-step-progress-bar@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "react-step-progress-bar@npm:1.0.3"
+  dependencies:
+    classnames: "npm:^2.2.6"
+    invariant: "npm:^2.2.4"
+    react-transition-group: "npm:^2.4.0"
+  peerDependencies:
+    react: ">=15.0.0"
+  checksum: 10c0/d1005794f796235486bf3c70dbb9e64e5e1232fc23494c0938b25f5a03e5ca5c794901c06bcc2c4af55593ff9d6e2d0fe80e6008ef951b90dc9ca284892b1005
+  languageName: node
+  linkType: hard
+
 "react-tooltip@npm:^5.26.4":
   version: 5.28.1
   resolution: "react-tooltip@npm:5.28.1"
@@ -6033,6 +6072,21 @@ __metadata:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
   checksum: 10c0/5f00407b6b55421ac1e2f6398300e0ce2f8dd7c1e2983de9977e0e1435a7b91138fab19dc3f5a0c5865df80f7dfec447cef2e79b705f27cda3bc276fe677e77f
+  languageName: node
+  linkType: hard
+
+"react-transition-group@npm:^2.4.0":
+  version: 2.9.0
+  resolution: "react-transition-group@npm:2.9.0"
+  dependencies:
+    dom-helpers: "npm:^3.4.0"
+    loose-envify: "npm:^1.4.0"
+    prop-types: "npm:^15.6.2"
+    react-lifecycles-compat: "npm:^3.0.4"
+  peerDependencies:
+    react: ">=15.0.0"
+    react-dom: ">=15.0.0"
+  checksum: 10c0/df40608e9defb6873290b9f2165921f17139b8edbb2019e2de38f77477f9cbd8fdb739b20e1e04cb16a513137c80e85cf5f0fff96049a94b740d389313394476
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces a new “Preview All Values” action in the Properties (table view) that triggers reading every readable property form and populates the Preview Value column in bulk. It aligns the behavior with the existing per-row request but streamlines validation during Thing Model interaction.

Key Changes

1. Added a batch test handler that iterates over all readable property forms (op includes readproperty).
2. Reused the existing single-read logic to avoid duplication (shared path for result mapping).
3. Integrated results map so the table updates cell states (error, success) correctly across repeated invocations.
4. Ensured re-requests overwrite previous values (e.g., after fixing a device/config error).
5. Preserved existing per-row click behavior (no regression).
