### PR TITLE
Add copy button for TD affordances (actions, properties, events)

### DIFF
--- a/src/components/Dialogs/AddFormDialog.tsx
+++ b/src/components/Dialogs/AddFormDialog.tsx
@@ -10,12 +10,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import { forwardRef, useContext, useState, useImperativeHandle } from "react";
+import React, {
+  forwardRef,
+  useContext,
+  useState,
+  useImperativeHandle,
+} from "react";
 import ReactDOM from "react-dom";
 import ediTDorContext from "../../context/ediTDorContext";
 import { checkIfFormIsInItem } from "../../utils/tdOperations";
 import DialogTemplate from "./DialogTemplate";
 import AddForm from "../App/AddForm";
+import type { IExplicitForm, IInteractionAffordance } from "../../types/form";
 
 export type OperationsType = "property" | "action" | "event" | "thing" | "";
 export type OperationsMap = PropertyMap | ActionMap | EventMap | ThingMap;
@@ -36,23 +42,18 @@ type ThingMap =
     ]
   | [];
 
-export interface AddFormDialogRef {
+export interface IAddFormDialogRef {
   openModal: () => void;
   close: () => void;
 }
 
-export interface ExplicitForm {
-  op: string[] | string;
-  href: string;
-}
-
-interface AddFormDialogProps {
+interface IAddFormDialogProps {
   type?: OperationsType;
-  interaction?: { forms?: ExplicitForm[]; type?: string };
+  interaction?: IInteractionAffordance;
   interactionName?: string;
 }
 
-const AddFormDialog = forwardRef<AddFormDialogRef, AddFormDialogProps>(
+const AddFormDialog = forwardRef<IAddFormDialogRef, IAddFormDialogProps>(
   (props, ref) => {
     const context: IEdiTDorContext = useContext(ediTDorContext);
     const [display, setDisplay] = useState<boolean>(() => {
@@ -64,7 +65,7 @@ const AddFormDialog = forwardRef<AddFormDialogRef, AddFormDialogProps>(
 
     const type: OperationsType = props.type || "";
     const name = type && type[0].toUpperCase() + type.slice(1);
-    const interaction = props.interaction ?? {};
+    const interaction = props.interaction;
     const interactionName = props.interactionName ?? "";
 
     useImperativeHandle(ref, () => {
@@ -111,10 +112,10 @@ const AddFormDialog = forwardRef<AddFormDialogRef, AddFormDialogProps>(
       }
     };
 
-    const checkDuplicates = (form: ExplicitForm): boolean => {
+    const checkDuplicates = (form: IExplicitForm): boolean => {
       const isDuplicate: boolean =
-        interaction.forms !== undefined
-          ? checkIfFormIsInItem(form, interaction as { forms: ExplicitForm[] })
+        interaction?.forms !== undefined
+          ? checkIfFormIsInItem(form, { forms: interaction.forms })
           : false;
       return isDuplicate;
     };
@@ -131,7 +132,7 @@ const AddFormDialog = forwardRef<AddFormDialogRef, AddFormDialogProps>(
     };
 
     const onHandleEventRightButton = () => {
-      const form: ExplicitForm = {
+      const form: IExplicitForm = {
         op: operations(type)
           .map((x) => {
             const element = document.getElementById(

--- a/src/components/Dialogs/AddPropertyDialog.tsx
+++ b/src/components/Dialogs/AddPropertyDialog.tsx
@@ -27,12 +27,12 @@ import DialogTemplate from "./DialogTemplate";
 
 const NO_TYPE = "undefined";
 
-export interface AddPropertyDialogRef {
+export interface IAddPropertyDialogRef {
   openModal: () => void;
   close?: () => void;
 }
 
-interface Property {
+interface IProperty {
   title: string;
   description?: string;
   type?: string;
@@ -43,7 +43,7 @@ interface Property {
   properties?: Record<string, any>;
 }
 
-export const AddPropertyDialog = forwardRef<AddPropertyDialogRef, {}>(
+export const AddPropertyDialog = forwardRef<IAddPropertyDialogRef, {}>(
   (_, ref) => {
     const context = useContext(ediTDorContext);
     const [display, setDisplay] = React.useState<boolean>(() => {
@@ -115,7 +115,7 @@ export const AddPropertyDialog = forwardRef<AddPropertyDialogRef, {}>(
         return;
       }
 
-      const property: Property = {
+      const property: IProperty = {
         title: (document.getElementById(`${type}-title`) as HTMLInputElement)
           .value,
         observable: (

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -65,7 +65,6 @@ const Action: React.FC<any> = (props) => {
     context.removeOneOfAKindReducer("actions", props.actionName);
   };
 
-
   const handleCopyAction = () => {
     try {
       const { updatedTD, newName } = copyAffordance({
@@ -101,9 +100,7 @@ const Action: React.FC<any> = (props) => {
           isExpanded ? "bg-gray-500" : ""
         }`}
       >
-        <h3 className="flex-grow px-2">
-          {action.title ?? props.actionName}
-        </h3>
+        <h3 className="flex-grow px-2">{action.title ?? props.actionName}</h3>
 
         {isExpanded && (
           <>
@@ -141,9 +138,7 @@ const Action: React.FC<any> = (props) => {
           </div>
         )}
 
-        <ul className="list-disc pl-6 text-base text-gray-300">
-          {attributes}
-        </ul>
+        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
 
         <div className="flex items-center justify-start pb-2 pt-2">
           <InfoIconWrapper

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -22,6 +22,7 @@ import InfoIconWrapper from "../../base/InfoIconWrapper";
 import { getFormsTooltipContent } from "../../../utils/TooltipMapper";
 import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
+import { copyAffordance } from "../../../utils/copyAffordance";
 
 const alreadyRenderedKeys = ["title", "forms", "description"];
 
@@ -31,7 +32,7 @@ const Action: React.FC<any> = (props) => {
 
   const addFormDialog = React.useRef<any>();
   const handleOpenAddFormDialog = () => {
-    addFormDialog.current.openModal();
+    addFormDialog.current?.openModal();
   };
 
   if (
@@ -64,34 +65,33 @@ const Action: React.FC<any> = (props) => {
     context.removeOneOfAKindReducer("actions", props.actionName);
   };
 
+
   const handleCopyAction = () => {
-    const parsedTD = context.parsedTD;
-    if (!parsedTD || !parsedTD.actions) {
-      console.error("parsedTD or actions missing", parsedTD);
-      return;
+    try {
+      const { updatedTD, newName } = copyAffordance({
+        parsedTD: context.parsedTD,
+        section: "actions",
+        originalName: props.actionName,
+        affordance: action,
+      });
+
+      context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
+
+      setIsExpanded(true);
+
+      setTimeout(() => {
+        document
+          .getElementById(`action-${newName}`)
+          ?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 100);
+    } catch (e) {
+      console.error(e);
     }
-    const originalName = props.actionName;
-    let newName = `${originalName}_copy`;
-    let counter = 1;
-    while (parsedTD.actions[newName]) {
-      newName = `${originalName}_copy_${counter++}`;
-    }
-    const copiedAction = structuredClone(action);
-    if (copiedAction.title) {
-      copiedAction.title = `${copiedAction.title} copy`;
-    }
-    const updatedParsedTD = {
-      ...parsedTD,
-      actions: {
-        ...parsedTD.actions,
-        [newName]: copiedAction,
-      },
-    };
-    context.updateOfflineTD(JSON.stringify(updatedParsedTD, null, 2));
   };
-  
+
   return (
     <details
+      id={`action-${props.actionName}`}
       className="mb-1"
       open={isExpanded}
       onToggle={() => setIsExpanded(!isExpanded)}
@@ -106,33 +106,32 @@ const Action: React.FC<any> = (props) => {
         </h3>
 
         {isExpanded && (
-  <>
-    <button
-      className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400 text-base"
-      title="Copy action"
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        handleCopyAction();
-      }}
-    >
-      <Copy size={16} color="white" />
-    </button>
+          <>
+            <button
+              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400 text-base"
+              title="Copy action"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                handleCopyAction();
+              }}
+            >
+              <Copy size={16} color="white" />
+            </button>
 
-    <button
-      className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
-      title="Delete action"
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        handleDeleteAction();
-      }}
-    >
-      <Trash2 size={16} color="white" />
-    </button>
-  </>
-)}
-
+            <button
+              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
+              title="Delete action"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                handleDeleteAction();
+              }}
+            >
+              <Trash2 size={16} color="white" />
+            </button>
+          </>
+        )}
       </summary>
 
       <div className="mb-4 rounded-b-lg bg-gray-500 px-2 pb-4">

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -31,6 +31,7 @@ const Action: React.FC<any> = (props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const addFormDialog = React.useRef<any>();
+
   const handleOpenAddFormDialog = () => {
     addFormDialog.current?.openModal();
   };
@@ -79,9 +80,10 @@ const Action: React.FC<any> = (props) => {
       setIsExpanded(true);
 
       setTimeout(() => {
-        document
-          .getElementById(`action-${newName}`)
-          ?.scrollIntoView({ behavior: "smooth", block: "center" });
+        document.getElementById(`action-${newName}`)?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
       }, 100);
     } catch (e) {
       console.error(e);
@@ -105,7 +107,7 @@ const Action: React.FC<any> = (props) => {
         {isExpanded && (
           <>
             <button
-              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400 text-base"
+              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg bg-gray-400 text-base"
               title="Copy action"
               onClick={(e) => {
                 e.preventDefault();
@@ -115,9 +117,8 @@ const Action: React.FC<any> = (props) => {
             >
               <Copy size={16} color="white" />
             </button>
-
             <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
+              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg rounded-tr-lg bg-gray-400 text-base"
               title="Delete action"
               onClick={(e) => {
                 e.preventDefault();
@@ -161,7 +162,7 @@ const Action: React.FC<any> = (props) => {
 
         {forms.map((form, i) => (
           <Form
-            key={`${i}-${form.href}`}
+            key={`${i}-${form?.href ?? "nohref"}`}
             form={form}
             propName={props.actionName}
             interactionType="action"
@@ -171,5 +172,4 @@ const Action: React.FC<any> = (props) => {
     </details>
   );
 };
-
 export default Action;

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 import React, { useContext, useState } from "react";
-import { Trash2 } from "react-feather";
+import { Trash2, Copy } from "react-feather";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -27,10 +27,9 @@ const alreadyRenderedKeys = ["title", "forms", "description"];
 
 const Action: React.FC<any> = (props) => {
   const context = useContext(ediTDorContext);
-
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const addFormDialog = React.useRef();
+  const addFormDialog = React.useRef<any>();
   const handleOpenAddFormDialog = () => {
     addFormDialog.current.openModal();
   };
@@ -54,18 +53,43 @@ const Action: React.FC<any> = (props) => {
     props.action,
     alreadyRenderedKeys
   );
-  const attributes = Object.keys(attributeListObject).map((x) => {
-    return (
-      <li key={x}>
-        {x} : {JSON.stringify(attributeListObject[x])}
-      </li>
-    );
-  });
+
+  const attributes = Object.keys(attributeListObject).map((x) => (
+    <li key={x}>
+      {x} : {JSON.stringify(attributeListObject[x])}
+    </li>
+  ));
 
   const handleDeleteAction = () => {
     context.removeOneOfAKindReducer("actions", props.actionName);
   };
 
+  const handleCopyAction = () => {
+    const parsedTD = context.parsedTD;
+    if (!parsedTD || !parsedTD.actions) {
+      console.error("parsedTD or actions missing", parsedTD);
+      return;
+    }
+    const originalName = props.actionName;
+    let newName = `${originalName}_copy`;
+    let counter = 1;
+    while (parsedTD.actions[newName]) {
+      newName = `${originalName}_copy_${counter++}`;
+    }
+    const copiedAction = structuredClone(action);
+    if (copiedAction.title) {
+      copiedAction.title = `${copiedAction.title} copy`;
+    }
+    const updatedParsedTD = {
+      ...parsedTD,
+      actions: {
+        ...parsedTD.actions,
+        [newName]: copiedAction,
+      },
+    };
+    context.updateOfflineTD(JSON.stringify(updatedParsedTD, null, 2));
+  };
+  
   return (
     <details
       className="mb-1"
@@ -73,17 +97,42 @@ const Action: React.FC<any> = (props) => {
       onToggle={() => setIsExpanded(!isExpanded)}
     >
       <summary
-        className={`flex cursor-pointer items-center rounded-t-lg pl-2 text-xl font-bold text-white ${isExpanded ? "bg-gray-500" : ""}`}
+        className={`flex cursor-pointer items-center rounded-t-lg pl-2 text-xl font-bold text-white ${
+          isExpanded ? "bg-gray-500" : ""
+        }`}
       >
-        <h3 className="flex-grow px-2">{action.title ?? props.actionName}</h3>
+        <h3 className="flex-grow px-2">
+          {action.title ?? props.actionName}
+        </h3>
+
         {isExpanded && (
-          <button
-            className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
-            onClick={handleDeleteAction}
-          >
-            <Trash2 size={16} color="white" />
-          </button>
-        )}
+  <>
+    <button
+      className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400 text-base"
+      title="Copy action"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        handleCopyAction();
+      }}
+    >
+      <Copy size={16} color="white" />
+    </button>
+
+    <button
+      className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
+      title="Delete action"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        handleDeleteAction();
+      }}
+    >
+      <Trash2 size={16} color="white" />
+    </button>
+  </>
+)}
+
       </summary>
 
       <div className="mb-4 rounded-b-lg bg-gray-500 px-2 pb-4">
@@ -92,7 +141,10 @@ const Action: React.FC<any> = (props) => {
             {action.description}
           </div>
         )}
-        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
+
+        <ul className="list-disc pl-6 text-base text-gray-300">
+          {attributes}
+        </ul>
 
         <div className="flex items-center justify-start pb-2 pt-2">
           <InfoIconWrapper
@@ -105,19 +157,21 @@ const Action: React.FC<any> = (props) => {
         </div>
 
         <AddFormElement onClick={handleOpenAddFormDialog} />
+
         <AddFormDialog
-          type={"action"}
+          type="action"
           interaction={action}
           interactionName={props.actionName}
           ref={addFormDialog}
         />
+
         {forms.map((form, i) => (
           <Form
             key={`${i}-${form.href}`}
             form={form}
             propName={props.actionName}
-            interactionType={"action"}
-          ></Form>
+            interactionType="action"
+          />
         ))}
       </div>
     </details>

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useContext, useState, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -21,21 +21,29 @@ import InfoIconWrapper from "../../base/InfoIconWrapper";
 import { getFormsTooltipContent } from "../../../utils/TooltipMapper";
 import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
-import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
 import type { IInteractionAffordance } from "../../../types/form";
+import { useCopiedAffordanceFocus } from "../../../hooks/useCopiedAffordanceFocus";
 const alreadyRenderedKeys = ["title", "forms", "description"];
 
 interface IAction {
   action: IInteractionAffordance;
   actionName: string;
+  copiedToken?: number;
+  onCopy: () => void;
 }
-const Action: React.FC<IAction> = ({ action, actionName }) => {
+const Action: React.FC<IAction> = ({
+  action,
+  actionName,
+  copiedToken,
+  onCopy,
+}) => {
   const context = useContext(ediTDorContext);
-  const [isExpanded, setIsExpanded] = useState(false);
   const addFormDialog = useRef<{ openModal: () => void; close: () => void }>(
     null
   );
+  const { containerRef, isExpanded, isHighlighted, setIsExpanded } =
+    useCopiedAffordanceFocus({ copiedToken });
   const forms = separateForms(action.forms);
   const attributeListObject = buildAttributeListObject(
     { name: actionName },
@@ -45,26 +53,12 @@ const Action: React.FC<IAction> = ({ action, actionName }) => {
   const handleDelete = () => {
     context.removeOneOfAKindReducer("actions", actionName);
   };
-  const handleCopy = () => {
-    const { updatedTD, newName } = copyAffordance({
-      parsedTD: context.parsedTD,
-      section: "actions",
-      originalName: actionName,
-      affordance: action,
-    });
-    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-    setIsExpanded(true);
-    setTimeout(() => {
-      document
-        .getElementById(`action-${newName}`)
-        ?.scrollIntoView({ behavior: "smooth", block: "center" });
-    }, 100);
-  };
 
   return (
     <details
+      ref={containerRef}
       id={`action-${actionName}`}
-      className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
+      className={`mb-2 rounded-lg transition-all ${isExpanded ? "overflow-hidden bg-gray-500" : ""} ${isHighlighted ? "border-2 border-green-400 ring-2 ring-green-300/70" : ""}`}
       open={isExpanded}
       onToggle={(e) => setIsExpanded(e.currentTarget.open)}
     >
@@ -78,7 +72,7 @@ const Action: React.FC<IAction> = ({ action, actionName }) => {
             onCopy={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              handleCopy();
+              onCopy();
             }}
             onDelete={(e) => {
               e.preventDefault();

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -23,16 +23,19 @@ import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
+import type { IInteractionAffordance } from "../../../types/form";
 const alreadyRenderedKeys = ["title", "forms", "description"];
 
 interface IAction {
-  action: any;
+  action: IInteractionAffordance;
   actionName: string;
 }
 const Action: React.FC<IAction> = ({ action, actionName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
-  const addFormDialog = useRef<{ openModal: () => void }>(null);
+  const addFormDialog = useRef<{ openModal: () => void; close: () => void }>(
+    null
+  );
   const forms = separateForms(action.forms);
   const attributeListObject = buildAttributeListObject(
     { name: actionName },
@@ -116,7 +119,7 @@ const Action: React.FC<IAction> = ({ action, actionName }) => {
 
         {forms.map((form, i) => (
           <Form
-            key={`${i}-${form?.href ?? "nohref"}`}
+            key={`${i}-${form?.href}`}
             form={form}
             propName={actionName}
             interactionType="action"

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -10,8 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useContext, useState } from "react";
-import { Trash2, Copy } from "react-feather";
+import React, { useContext, useState, useRef } from "react";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -23,140 +22,95 @@ import { getFormsTooltipContent } from "../../../utils/TooltipMapper";
 import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
-
+import AffordanceButtons from "./AffordanceButtons";
 const alreadyRenderedKeys = ["title", "forms", "description"];
 
-const Action: React.FC<any> = (props) => {
+interface IAction {
+  action: any;
+  actionName: string;
+}
+const Action: React.FC<IAction> = ({ action, actionName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
-
-  const addFormDialog = React.useRef<any>();
-
-  const handleOpenAddFormDialog = () => {
-    addFormDialog.current?.openModal();
-  };
-
-  if (
-    Object.keys(props.action).length === 0 &&
-    props.action.constructor !== Object
-  ) {
-    return (
-      <div className="text-3xl text-white">
-        Action could not be rendered because mandatory fields are missing.
-      </div>
-    );
-  }
-
-  const action = props.action;
-  const forms = separateForms(props.action.forms);
-
+  const addFormDialog = useRef<{ openModal: () => void }>(null);
+  const forms = separateForms(action.forms);
   const attributeListObject = buildAttributeListObject(
-    { name: props.actionName },
-    props.action,
+    { name: actionName },
+    action,
     alreadyRenderedKeys
   );
-
-  const attributes = Object.keys(attributeListObject).map((x) => (
-    <li key={x}>
-      {x} : {JSON.stringify(attributeListObject[x])}
-    </li>
-  ));
-
-  const handleDeleteAction = () => {
-    context.removeOneOfAKindReducer("actions", props.actionName);
+  const handleDelete = () => {
+    context.removeOneOfAKindReducer("actions", actionName);
   };
-
-  const handleCopyAction = () => {
-    try {
-      const { updatedTD, newName } = copyAffordance({
-        parsedTD: context.parsedTD,
-        section: "actions",
-        originalName: props.actionName,
-        affordance: action,
-      });
-
-      context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-
-      setIsExpanded(true);
-
-      setTimeout(() => {
-        document.getElementById(`action-${newName}`)?.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
-      }, 100);
-    } catch (e) {
-      console.error(e);
-    }
+  const handleCopy = () => {
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: context.parsedTD,
+      section: "actions",
+      originalName: actionName,
+      affordance: action,
+    });
+    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
+    setIsExpanded(true);
+    setTimeout(() => {
+      document
+        .getElementById(`action-${newName}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 100);
   };
 
   return (
     <details
-      id={`action-${props.actionName}`}
-      className="mb-1"
+      id={`action-${actionName}`}
+      className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
       open={isExpanded}
       onToggle={() => setIsExpanded(!isExpanded)}
     >
-      <summary
-        className={`flex cursor-pointer items-center rounded-t-lg pl-2 text-xl font-bold text-white ${
-          isExpanded ? "bg-gray-500" : ""
-        }`}
-      >
-        <h3 className="flex-grow px-2">{action.title ?? props.actionName}</h3>
+      <summary className="flex cursor-pointer items-center py-1 pl-2 text-xl font-bold text-white">
+        <h3 className="flex-grow px-2">{action.title ?? actionName}</h3>
 
         {isExpanded && (
-          <>
-            <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg bg-gray-400 text-base"
-              title="Copy action"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleCopyAction();
-              }}
-            >
-              <Copy size={16} color="white" />
-            </button>
-            <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg rounded-tr-lg bg-gray-400 text-base"
-              title="Delete action"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleDeleteAction();
-              }}
-            >
-              <Trash2 size={16} color="white" />
-            </button>
-          </>
+          <AffordanceButtons
+            copyTitle="Copy action"
+            deleteTitle="Delete action"
+            onCopy={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleCopy();
+            }}
+            onDelete={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleDelete();
+            }}
+          />
         )}
       </summary>
 
-      <div className="mb-4 rounded-b-lg bg-gray-500 px-2 pb-4">
+      <div className="px-2 pb-4">
         {action.description && (
           <div className="px-2 pb-2 text-lg text-gray-400">
             {action.description}
           </div>
         )}
 
-        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
+        <ul className="list-disc pl-6 text-base text-gray-300">
+          {Object.entries(attributeListObject).map(([k, v]) => (
+            <li key={k}>
+              {k}: {JSON.stringify(v)}
+            </li>
+          ))}
+        </ul>
 
-        <div className="flex items-center justify-start pb-2 pt-2">
-          <InfoIconWrapper
-            className="flex-grow"
-            tooltip={getFormsTooltipContent()}
-            id="actions"
-          >
-            <h4 className="pr-1 text-lg font-bold text-white">Forms</h4>
-          </InfoIconWrapper>
-        </div>
+        <InfoIconWrapper tooltip={getFormsTooltipContent()} id="actions">
+          <h4 className="text-lg font-bold text-white">Forms</h4>
+        </InfoIconWrapper>
 
-        <AddFormElement onClick={handleOpenAddFormDialog} />
+        <AddFormElement onClick={() => addFormDialog.current?.openModal()} />
 
         <AddFormDialog
           type="action"
           interaction={action}
-          interactionName={props.actionName}
+          interactionName={actionName}
           ref={addFormDialog}
         />
 
@@ -164,7 +118,7 @@ const Action: React.FC<any> = (props) => {
           <Form
             key={`${i}-${form?.href ?? "nohref"}`}
             form={form}
-            propName={props.actionName}
+            propName={actionName}
             interactionType="action"
           />
         ))}
@@ -172,4 +126,5 @@ const Action: React.FC<any> = (props) => {
     </details>
   );
 };
+
 export default Action;

--- a/src/components/TDViewer/components/Action.tsx
+++ b/src/components/TDViewer/components/Action.tsx
@@ -63,7 +63,7 @@ const Action: React.FC<IAction> = ({ action, actionName }) => {
       id={`action-${actionName}`}
       className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
       open={isExpanded}
-      onToggle={() => setIsExpanded(!isExpanded)}
+      onToggle={(e) => setIsExpanded(e.currentTarget.open)}
     >
       <summary className="flex cursor-pointer items-center py-1 pl-2 text-xl font-bold text-white">
         <h3 className="flex-grow px-2">{action.title ?? actionName}</h3>

--- a/src/components/TDViewer/components/AffordanceButtons.tsx
+++ b/src/components/TDViewer/components/AffordanceButtons.tsx
@@ -29,6 +29,7 @@ const AffordanceButtons: React.FC<IProps> = ({
   return (
     <div className="flex self-stretch">
       <button
+        aria-label={copyTitle}
         className="flex w-14 items-center justify-center bg-gray-400 transition-colors hover:bg-gray-500"
         title={copyTitle}
         onClick={onCopy}
@@ -37,6 +38,7 @@ const AffordanceButtons: React.FC<IProps> = ({
       </button>
 
       <button
+        aria-label={deleteTitle}
         className="flex w-14 items-center justify-center rounded-tr-lg border-l border-gray-500 bg-gray-400 transition-colors hover:bg-gray-500"
         title={deleteTitle}
         onClick={onDelete}

--- a/src/components/TDViewer/components/AffordanceButtons.tsx
+++ b/src/components/TDViewer/components/AffordanceButtons.tsx
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import React from "react";
+import { Copy, Trash2 } from "react-feather";
+
+interface Props {
+  onCopy: (e: React.MouseEvent) => void;
+  onDelete: (e: React.MouseEvent) => void;
+  copyTitle: string;
+  deleteTitle: string;
+}
+
+const AffordanceButtons: React.FC<Props> = ({
+  onCopy,
+  onDelete,
+  copyTitle,
+  deleteTitle,
+}) => {
+  return (
+    <div className="flex self-stretch">
+      <button
+        className="flex w-14 items-center justify-center bg-gray-400 transition-colors hover:bg-gray-500"
+        title={copyTitle}
+        onClick={onCopy}
+      >
+        <Copy size={20} color="white" />
+      </button>
+
+      <button
+        className="flex w-14 items-center justify-center rounded-tr-lg border-l border-gray-500 bg-gray-400 transition-colors hover:bg-gray-500"
+        title={deleteTitle}
+        onClick={onDelete}
+      >
+        <Trash2 size={20} color="white" />
+      </button>
+    </div>
+  );
+};
+
+export default AffordanceButtons;

--- a/src/components/TDViewer/components/AffordanceButtons.tsx
+++ b/src/components/TDViewer/components/AffordanceButtons.tsx
@@ -13,14 +13,14 @@
 import React from "react";
 import { Copy, Trash2 } from "react-feather";
 
-interface Props {
+interface IProps {
   onCopy: (e: React.MouseEvent) => void;
   onDelete: (e: React.MouseEvent) => void;
   copyTitle: string;
   deleteTitle: string;
 }
 
-const AffordanceButtons: React.FC<Props> = ({
+const AffordanceButtons: React.FC<IProps> = ({
   onCopy,
   onDelete,
   copyTitle,

--- a/src/components/TDViewer/components/Event.tsx
+++ b/src/components/TDViewer/components/Event.tsx
@@ -100,9 +100,7 @@ const Event: React.FC<any> = (props) => {
           isExpanded ? "bg-gray-500" : ""
         }`}
       >
-        <div className="flex-grow px-2">
-          {event.title ?? props.eventName}
-        </div>
+        <div className="flex-grow px-2">{event.title ?? props.eventName}</div>
 
         {isExpanded && (
           <>
@@ -142,9 +140,7 @@ const Event: React.FC<any> = (props) => {
           </div>
         )}
 
-        <ul className="list-disc pl-6 text-base text-gray-300">
-          {attributes}
-        </ul>
+        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
 
         <div className="flex items-center justify-start pb-2 pt-2">
           <InfoIconWrapper

--- a/src/components/TDViewer/components/Event.tsx
+++ b/src/components/TDViewer/components/Event.tsx
@@ -31,35 +31,19 @@ const Event: React.FC<any> = (props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const addFormDialog = useRef<{ openModal: () => void }>(null);
+
   const handleOpenAddFormDialog = () => {
     addFormDialog.current?.openModal();
   };
 
-  if (
-    Object.keys(props.event).length === 0 &&
-    props.event.constructor !== Object
-  ) {
-    return (
-      <div className="text-3xl text-white">
-        Event could not be rendered because mandatory fields are missing.
-      </div>
-    );
-  }
-
   const event = props.event;
-  const forms = separateForms(props.event.forms);
+  const forms = separateForms(event.forms);
 
   const attributeListObject = buildAttributeListObject(
     { name: props.eventName },
-    props.event,
+    event,
     alreadyRenderedKeys
   );
-
-  const attributes = Object.keys(attributeListObject).map((x) => (
-    <li key={x}>
-      {x} : {JSON.stringify(attributeListObject[x])}
-    </li>
-  ));
 
   const handleDeleteEventClicked = () => {
     context.removeOneOfAKindReducer("events", props.eventName);
@@ -75,7 +59,6 @@ const Event: React.FC<any> = (props) => {
       });
 
       context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-
       setIsExpanded(true);
 
       setTimeout(() => {
@@ -104,9 +87,8 @@ const Event: React.FC<any> = (props) => {
 
         {isExpanded && (
           <>
-            {/* COPY BUTTON */}
             <button
-              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400 text-base"
+              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400"
               title="Copy event"
               onClick={(e) => {
                 e.preventDefault();
@@ -117,9 +99,8 @@ const Event: React.FC<any> = (props) => {
               <Copy size={16} color="white" />
             </button>
 
-            {/* DELETE BUTTON */}
             <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
+              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg rounded-tr-lg bg-gray-400"
               title="Delete event"
               onClick={(e) => {
                 e.preventDefault();
@@ -140,19 +121,20 @@ const Event: React.FC<any> = (props) => {
           </div>
         )}
 
-        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
+        <ul className="list-disc pl-6 text-base text-gray-300">
+          {Object.entries(attributeListObject).map(([k, v]) => (
+            <li key={k}>
+              {k}: {JSON.stringify(v)}
+            </li>
+          ))}
+        </ul>
 
-        <div className="flex items-center justify-start pb-2 pt-2">
-          <InfoIconWrapper
-            className="flex-grow"
-            tooltip={getFormsTooltipContent()}
-            id="events"
-          >
-            <h4 className="pr-1 text-lg font-bold text-white">Forms</h4>
-          </InfoIconWrapper>
-        </div>
+        <InfoIconWrapper tooltip={getFormsTooltipContent()} id="events">
+          <h4 className="text-lg font-bold text-white">Forms</h4>
+        </InfoIconWrapper>
 
         <AddFormElement onClick={handleOpenAddFormDialog} />
+
         <AddFormDialog
           type="event"
           interaction={event}

--- a/src/components/TDViewer/components/Event.tsx
+++ b/src/components/TDViewer/components/Event.tsx
@@ -11,7 +11,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 import React, { useContext, useState, useRef } from "react";
-import { Trash2, Copy } from "react-feather";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -23,104 +22,73 @@ import { getFormsTooltipContent } from "../../../utils/TooltipMapper";
 import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
-
+import AffordanceButtons from "./AffordanceButtons";
 const alreadyRenderedKeys = ["title", "forms", "description"];
-
-const Event: React.FC<any> = (props) => {
+interface IEvent {
+  event: any;
+  eventName: string;
+}
+const Event: React.FC<IEvent> = ({ event, eventName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
-
   const addFormDialog = useRef<{ openModal: () => void }>(null);
-
-  const handleOpenAddFormDialog = () => {
-    addFormDialog.current?.openModal();
-  };
-
-  const event = props.event;
   const forms = separateForms(event.forms);
-
   const attributeListObject = buildAttributeListObject(
-    { name: props.eventName },
+    { name: eventName },
     event,
     alreadyRenderedKeys
   );
-
-  const handleDeleteEventClicked = () => {
-    context.removeOneOfAKindReducer("events", props.eventName);
+  const handleDelete = () => {
+    context.removeOneOfAKindReducer("events", eventName);
   };
-
-  const handleCopyEvent = () => {
-    try {
-      const { updatedTD, newName } = copyAffordance({
-        parsedTD: context.parsedTD,
-        section: "events",
-        originalName: props.eventName,
-        affordance: event,
-      });
-
-      context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-      setIsExpanded(true);
-
-      setTimeout(() => {
-        document
-          .getElementById(`event-${newName}`)
-          ?.scrollIntoView({ behavior: "smooth", block: "center" });
-      }, 100);
-    } catch (e) {
-      console.error(e);
-    }
+  const handleCopy = () => {
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: context.parsedTD,
+      section: "events",
+      originalName: eventName,
+      affordance: event,
+    });
+    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
+    setIsExpanded(true);
+    setTimeout(() => {
+      document
+        .getElementById(`event-${newName}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 100);
   };
 
   return (
     <details
-      id={`event-${props.eventName}`}
-      className="mb-1"
+      id={`event-${eventName}`}
+      className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
       open={isExpanded}
       onToggle={() => setIsExpanded(!isExpanded)}
     >
-      <summary
-        className={`flex cursor-pointer items-center rounded-t-lg pl-2 text-xl font-bold text-white ${
-          isExpanded ? "bg-gray-500" : ""
-        }`}
-      >
-        <div className="flex-grow px-2">{event.title ?? props.eventName}</div>
-
+      <summary className="flex cursor-pointer items-center py-1 pl-2 text-xl font-bold text-white">
+        <div className="flex-grow px-2">{event.title ?? eventName}</div>
         {isExpanded && (
-          <>
-            <button
-              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400"
-              title="Copy event"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleCopyEvent();
-              }}
-            >
-              <Copy size={16} color="white" />
-            </button>
-
-            <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg rounded-tr-lg bg-gray-400"
-              title="Delete event"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleDeleteEventClicked();
-              }}
-            >
-              <Trash2 size={16} color="white" />
-            </button>
-          </>
+          <AffordanceButtons
+            copyTitle="Copy event"
+            deleteTitle="Delete event"
+            onCopy={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleCopy();
+            }}
+            onDelete={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleDelete();
+            }}
+          />
         )}
       </summary>
-
-      <div className="mb-4 rounded-b-lg bg-gray-500 px-2 pb-4">
+      <div className="px-2 pb-4">
         {event.description && (
           <div className="px-2 pb-2 text-lg text-gray-400">
             {event.description}
           </div>
         )}
-
         <ul className="list-disc pl-6 text-base text-gray-300">
           {Object.entries(attributeListObject).map(([k, v]) => (
             <li key={k}>
@@ -128,25 +96,21 @@ const Event: React.FC<any> = (props) => {
             </li>
           ))}
         </ul>
-
         <InfoIconWrapper tooltip={getFormsTooltipContent()} id="events">
           <h4 className="text-lg font-bold text-white">Forms</h4>
         </InfoIconWrapper>
-
-        <AddFormElement onClick={handleOpenAddFormDialog} />
-
+        <AddFormElement onClick={() => addFormDialog.current?.openModal()} />
         <AddFormDialog
           type="event"
           interaction={event}
-          interactionName={props.eventName}
+          interactionName={eventName}
           ref={addFormDialog}
         />
-
         {forms.map((form, i) => (
           <Form
             key={`${i}-${form.href}`}
             form={form}
-            propName={props.eventName}
+            propName={eventName}
             interactionType="event"
           />
         ))}

--- a/src/components/TDViewer/components/Event.tsx
+++ b/src/components/TDViewer/components/Event.tsx
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useContext, useState, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -21,20 +21,23 @@ import InfoIconWrapper from "../../base/InfoIconWrapper";
 import { getFormsTooltipContent } from "../../../utils/TooltipMapper";
 import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
-import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
-import type { InteractionAffordance } from "../../../types/form";
+import type { IInteractionAffordance } from "../../../types/form";
+import { useCopiedAffordanceFocus } from "../../../hooks/useCopiedAffordanceFocus";
 const alreadyRenderedKeys = ["title", "forms", "description"];
 interface IEvent {
-  event: InteractionAffordance;
+  event: IInteractionAffordance;
   eventName: string;
+  copiedToken?: number;
+  onCopy: () => void;
 }
-const Event: React.FC<IEvent> = ({ event, eventName }) => {
+const Event: React.FC<IEvent> = ({ event, eventName, copiedToken, onCopy }) => {
   const context = useContext(ediTDorContext);
-  const [isExpanded, setIsExpanded] = useState(false);
   const addFormDialog = useRef<{ openModal: () => void; close: () => void }>(
     null
   );
+  const { containerRef, isExpanded, isHighlighted, setIsExpanded } =
+    useCopiedAffordanceFocus({ copiedToken });
   const forms = separateForms(event.forms);
   const attributeListObject = buildAttributeListObject(
     { name: eventName },
@@ -44,26 +47,12 @@ const Event: React.FC<IEvent> = ({ event, eventName }) => {
   const handleDelete = () => {
     context.removeOneOfAKindReducer("events", eventName);
   };
-  const handleCopy = () => {
-    const { updatedTD, newName } = copyAffordance({
-      parsedTD: context.parsedTD,
-      section: "events",
-      originalName: eventName,
-      affordance: event,
-    });
-    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-    setIsExpanded(true);
-    setTimeout(() => {
-      document
-        .getElementById(`event-${newName}`)
-        ?.scrollIntoView({ behavior: "smooth", block: "center" });
-    }, 100);
-  };
 
   return (
     <details
+      ref={containerRef}
       id={`event-${eventName}`}
-      className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
+      className={`mb-2 rounded-lg transition-all ${isExpanded ? "overflow-hidden bg-gray-500" : ""} ${isHighlighted ? "border-2 border-green-400 ring-2 ring-green-300/70" : ""}`}
       open={isExpanded}
       onToggle={(e) => setIsExpanded(e.currentTarget.open)}
     >
@@ -76,7 +65,7 @@ const Event: React.FC<IEvent> = ({ event, eventName }) => {
             onCopy={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              handleCopy();
+              onCopy();
             }}
             onDelete={(e) => {
               e.preventDefault();

--- a/src/components/TDViewer/components/Event.tsx
+++ b/src/components/TDViewer/components/Event.tsx
@@ -62,7 +62,7 @@ const Event: React.FC<IEvent> = ({ event, eventName }) => {
       id={`event-${eventName}`}
       className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
       open={isExpanded}
-      onToggle={() => setIsExpanded(!isExpanded)}
+      onToggle={(e) => setIsExpanded(e.currentTarget.open)}
     >
       <summary className="flex cursor-pointer items-center py-1 pl-2 text-xl font-bold text-white">
         <div className="flex-grow px-2">{event.title ?? eventName}</div>

--- a/src/components/TDViewer/components/Event.tsx
+++ b/src/components/TDViewer/components/Event.tsx
@@ -23,15 +23,18 @@ import Form from "./Form";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
+import type { InteractionAffordance } from "../../../types/form";
 const alreadyRenderedKeys = ["title", "forms", "description"];
 interface IEvent {
-  event: any;
+  event: InteractionAffordance;
   eventName: string;
 }
 const Event: React.FC<IEvent> = ({ event, eventName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
-  const addFormDialog = useRef<{ openModal: () => void }>(null);
+  const addFormDialog = useRef<{ openModal: () => void; close: () => void }>(
+    null
+  );
   const forms = separateForms(event.forms);
   const attributeListObject = buildAttributeListObject(
     { name: eventName },

--- a/src/components/TDViewer/components/Form.tsx
+++ b/src/components/TDViewer/components/Form.tsx
@@ -15,7 +15,7 @@ import ediTDorContext from "../../../context/ediTDorContext";
 import FormDetails from "../base/FormDetails";
 import UndefinedForm from "../base/UndefinedForm";
 import { formConfigurations } from "../../../services/form";
-import type { OpKeys } from "../../../types/form";
+import type { FormProps, OpKeys } from "../../../types/form";
 
 const typeToJSONKey = (type: string): string => {
   const typeToJSONKey: Record<string, string> = {
@@ -29,12 +29,7 @@ const typeToJSONKey = (type: string): string => {
 };
 
 interface IFormComponentProps {
-  form: {
-    href: string;
-    contentType: string;
-    op: string;
-    actualIndex: number;
-  };
+  form: FormProps;
   propName: string;
   interactionType: "thing" | "property" | "action" | "event";
 }

--- a/src/components/TDViewer/components/InteractionSection.tsx
+++ b/src/components/TDViewer/components/InteractionSection.tsx
@@ -38,6 +38,8 @@ import ErrorDialog from "../../Dialogs/ErrorDialog";
 import { readAllReadablePropertyForms } from "../../../services/thingsApiService";
 import { AlertTriangle } from "react-feather";
 import { getErrorSummary } from "../../../utils/arrays";
+import { copyAffordance } from "../../../utils/copyAffordance";
+import type { IInteractionAffordance } from "../../../types/form";
 
 const SORT_ASC = "asc";
 const SORT_DESC = "desc";
@@ -48,6 +50,12 @@ interface IInteractionSectionProps {
 }
 
 type InteractionKey = "properties" | "actions" | "events";
+
+interface ICopiedAffordanceTarget {
+  section: InteractionKey;
+  name: string;
+  token: number;
+}
 
 /**
  * Renders a section for an interaction (Property, Action, Event) with a
@@ -99,6 +107,8 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
   >({});
 
   const [isTestingAll, setIsTestingAll] = useState(false);
+  const [copiedAffordance, setCopiedAffordance] =
+    useState<ICopiedAffordanceTarget | null>(null);
 
   const interaction = props.interaction.toLowerCase() as InteractionKey;
 
@@ -381,6 +391,26 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
     });
   };
 
+  const handleCopyAffordance = (
+    section: InteractionKey,
+    originalName: string,
+    affordance: IInteractionAffordance
+  ) => {
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: context.parsedTD,
+      section,
+      originalName,
+      affordance,
+    });
+
+    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
+    setCopiedAffordance({
+      section,
+      name: newName,
+      token: Date.now(),
+    });
+  };
+
   const buildChildren = () => {
     const filteredInteractions = applyFilter();
 
@@ -390,7 +420,22 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
           <Property
             prop={(filteredInteractions as any)[key]}
             propName={key}
-            key={index}
+            copiedToken={
+              copiedAffordance?.section === "properties" &&
+              copiedAffordance.name === key
+                ? copiedAffordance.token
+                : undefined
+            }
+            onCopy={() =>
+              handleCopyAffordance(
+                "properties",
+                key,
+                (
+                  filteredInteractions as Record<string, IInteractionAffordance>
+                )[key]
+              )
+            }
+            key={key}
           />
         ));
       }
@@ -475,20 +520,50 @@ const InteractionSection: React.FC<IInteractionSectionProps> = (props) => {
       );
     }
     if (td.actions && interaction === "actions") {
-      return Object.keys(filteredInteractions).map((key, index) => (
+      return Object.keys(filteredInteractions).map((key) => (
         <Action
           action={(filteredInteractions as any)[key]}
           actionName={key}
-          key={index}
+          copiedToken={
+            copiedAffordance?.section === "actions" &&
+            copiedAffordance.name === key
+              ? copiedAffordance.token
+              : undefined
+          }
+          onCopy={() =>
+            handleCopyAffordance(
+              "actions",
+              key,
+              (filteredInteractions as Record<string, IInteractionAffordance>)[
+                key
+              ]
+            )
+          }
+          key={key}
         />
       ));
     }
     if (td.events && interaction === "events") {
-      return Object.keys(filteredInteractions).map((key, index) => (
+      return Object.keys(filteredInteractions).map((key) => (
         <Event
           event={(filteredInteractions as any)[key]}
           eventName={key}
-          key={index}
+          copiedToken={
+            copiedAffordance?.section === "events" &&
+            copiedAffordance.name === key
+              ? copiedAffordance.token
+              : undefined
+          }
+          onCopy={() =>
+            handleCopyAffordance(
+              "events",
+              key,
+              (filteredInteractions as Record<string, IInteractionAffordance>)[
+                key
+              ]
+            )
+          }
+          key={key}
         />
       ));
     }

--- a/src/components/TDViewer/components/Property.tsx
+++ b/src/components/TDViewer/components/Property.tsx
@@ -26,55 +26,20 @@ import { copyAffordance } from "../../../utils/copyAffordance";
 
 const alreadyRenderedKeys = ["title", "forms", "description"];
 
-interface IProperty {
-  prop: {
-    title: string;
-    forms: Array<{
-      href: string;
-      contentType?: string;
-      op?: string | string[];
-      [key: string]: any;
-    }>;
-    description?: string;
-    [key: string]: any;
-  };
-  propName: string;
-}
-
-const Property: React.FC<IProperty> = (props) => {
+const Property: React.FC<any> = (props) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
 
   const addFormDialog = useRef<{ openModal: () => void }>(null);
-  const handleOpenAddFormDialog = () => {
-    addFormDialog.current?.openModal();
-  };
-
-  if (
-    Object.keys(props.prop).length === 0 &&
-    props.prop.constructor !== Object
-  ) {
-    return (
-      <div className="text-3xl text-white">
-        Property could not be rendered because mandatory fields are missing.
-      </div>
-    );
-  }
 
   const property = props.prop;
-  const forms = separateForms(structuredClone(props.prop.forms));
+  const forms = separateForms(structuredClone(property.forms));
 
   const attributeListObject = buildAttributeListObject(
     { name: props.propName },
-    props.prop,
+    property,
     alreadyRenderedKeys
   );
-
-  const attributes = Object.keys(attributeListObject).map((x) => (
-    <li key={x}>
-      {x} : {JSON.stringify(attributeListObject[x])}
-    </li>
-  ));
 
   const handleDeletePropertyClicked = () => {
     context.removeOneOfAKindReducer("properties", props.propName);
@@ -90,7 +55,6 @@ const Property: React.FC<IProperty> = (props) => {
       });
 
       context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-
       setIsExpanded(true);
 
       setTimeout(() => {
@@ -119,9 +83,8 @@ const Property: React.FC<IProperty> = (props) => {
 
         {isExpanded && (
           <>
-            {/* COPY BUTTON */}
             <button
-              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400 text-base"
+              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400"
               title="Copy property"
               onClick={(e) => {
                 e.preventDefault();
@@ -132,9 +95,8 @@ const Property: React.FC<IProperty> = (props) => {
               <Copy size={16} color="white" />
             </button>
 
-            {/* DELETE BUTTON */}
             <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-md rounded-tr-md bg-gray-400 text-base"
+              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg rounded-tr-lg bg-gray-400"
               title="Delete property"
               onClick={(e) => {
                 e.preventDefault();
@@ -155,15 +117,20 @@ const Property: React.FC<IProperty> = (props) => {
           </div>
         )}
 
-        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
+        <ul className="list-disc pl-6 text-base text-gray-300">
+          {Object.entries(attributeListObject).map(([k, v]) => (
+            <li key={k}>
+              {k}: {JSON.stringify(v)}
+            </li>
+          ))}
+        </ul>
 
-        <div className="flex items-center justify-start pb-2 pt-2">
-          <InfoIconWrapper tooltip={getFormsTooltipContent()} id="properties">
-            <h4 className="pr-1 text-lg font-bold text-white">Forms</h4>
-          </InfoIconWrapper>
-        </div>
+        <InfoIconWrapper tooltip={getFormsTooltipContent()} id="properties">
+          <h4 className="text-lg font-bold text-white">Forms</h4>
+        </InfoIconWrapper>
 
-        <AddFormElement onClick={handleOpenAddFormDialog} />
+        <AddFormElement onClick={() => addFormDialog.current?.openModal()} />
+
         <AddFormDialog
           type="property"
           interaction={property}

--- a/src/components/TDViewer/components/Property.tsx
+++ b/src/components/TDViewer/components/Property.tsx
@@ -115,9 +115,7 @@ const Property: React.FC<IProperty> = (props) => {
           isExpanded ? "bg-gray-500" : ""
         }`}
       >
-        <h3 className="flex-grow px-2">
-          {property.title ?? props.propName}
-        </h3>
+        <h3 className="flex-grow px-2">{property.title ?? props.propName}</h3>
 
         {isExpanded && (
           <>
@@ -157,9 +155,7 @@ const Property: React.FC<IProperty> = (props) => {
           </div>
         )}
 
-        <ul className="list-disc pl-6 text-base text-gray-300">
-          {attributes}
-        </ul>
+        <ul className="list-disc pl-6 text-base text-gray-300">{attributes}</ul>
 
         <div className="flex items-center justify-start pb-2 pt-2">
           <InfoIconWrapper tooltip={getFormsTooltipContent()} id="properties">

--- a/src/components/TDViewer/components/Property.tsx
+++ b/src/components/TDViewer/components/Property.tsx
@@ -23,11 +23,24 @@ import AddFormDialog from "../../Dialogs/AddFormDialog";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
-const alreadyRenderedKeys = ["title", "forms", "description"];
+
 interface IProperty {
-  prop: any;
+  prop: {
+    title: string;
+    forms: Array<{
+      href: string;
+      contentType?: string;
+      op?: string | string[];
+      [key: string]: any;
+    }>;
+    description?: string;
+    [key: string]: any;
+  };
   propName: string;
 }
+
+const alreadyRenderedKeys = ["title", "forms", "description"];
+
 const Property: React.FC<IProperty> = ({ prop, propName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -62,7 +75,7 @@ const Property: React.FC<IProperty> = ({ prop, propName }) => {
       id={`property-${propName}`}
       className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
       open={isExpanded}
-      onToggle={() => setIsExpanded(!isExpanded)}
+      onToggle={(e) => setIsExpanded(e.currentTarget.open)}
     >
       <summary className="flex cursor-pointer items-center py-1 pl-2 text-xl font-bold text-white">
         <h3 className="flex-grow px-2">{prop.title ?? propName}</h3>

--- a/src/components/TDViewer/components/Property.tsx
+++ b/src/components/TDViewer/components/Property.tsx
@@ -23,19 +23,10 @@ import AddFormDialog from "../../Dialogs/AddFormDialog";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
+import type { IInteractionAffordance } from "../../../types/form";
 
 interface IProperty {
-  prop: {
-    title: string;
-    forms: Array<{
-      href: string;
-      contentType?: string;
-      op?: string | string[];
-      [key: string]: any;
-    }>;
-    description?: string;
-    [key: string]: any;
-  };
+  prop: IInteractionAffordance;
   propName: string;
 }
 
@@ -44,7 +35,9 @@ const alreadyRenderedKeys = ["title", "forms", "description"];
 const Property: React.FC<IProperty> = ({ prop, propName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
-  const addFormDialog = useRef<{ openModal: () => void }>(null);
+  const addFormDialog = useRef<{ openModal: () => void; close: () => void }>(
+    null
+  );
   const forms = separateForms(structuredClone(prop.forms));
   const attributeListObject = buildAttributeListObject(
     { name: propName },

--- a/src/components/TDViewer/components/Property.tsx
+++ b/src/components/TDViewer/components/Property.tsx
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useContext, useState, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -21,23 +21,31 @@ import { getFormsTooltipContent } from "../../../utils/TooltipMapper";
 import Form from "./Form";
 import AddFormDialog from "../../Dialogs/AddFormDialog";
 import AddFormElement from "../base/AddFormElement";
-import { copyAffordance } from "../../../utils/copyAffordance";
 import AffordanceButtons from "./AffordanceButtons";
 import type { IInteractionAffordance } from "../../../types/form";
+import { useCopiedAffordanceFocus } from "../../../hooks/useCopiedAffordanceFocus";
 
 interface IProperty {
   prop: IInteractionAffordance;
   propName: string;
+  copiedToken?: number;
+  onCopy: () => void;
 }
 
 const alreadyRenderedKeys = ["title", "forms", "description"];
 
-const Property: React.FC<IProperty> = ({ prop, propName }) => {
+const Property: React.FC<IProperty> = ({
+  prop,
+  propName,
+  copiedToken,
+  onCopy,
+}) => {
   const context = useContext(ediTDorContext);
-  const [isExpanded, setIsExpanded] = useState(false);
   const addFormDialog = useRef<{ openModal: () => void; close: () => void }>(
     null
   );
+  const { containerRef, isExpanded, isHighlighted, setIsExpanded } =
+    useCopiedAffordanceFocus({ copiedToken });
   const forms = separateForms(structuredClone(prop.forms));
   const attributeListObject = buildAttributeListObject(
     { name: propName },
@@ -47,26 +55,12 @@ const Property: React.FC<IProperty> = ({ prop, propName }) => {
   const handleDeleteProperty = () => {
     context.removeOneOfAKindReducer("properties", propName);
   };
-  const handleCopyProperty = () => {
-    const { updatedTD, newName } = copyAffordance({
-      parsedTD: context.parsedTD,
-      section: "properties",
-      originalName: propName,
-      affordance: prop,
-    });
-    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-    setIsExpanded(true);
-    setTimeout(() => {
-      document
-        .getElementById(`property-${newName}`)
-        ?.scrollIntoView({ behavior: "smooth", block: "center" });
-    }, 100);
-  };
 
   return (
     <details
+      ref={containerRef}
       id={`property-${propName}`}
-      className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
+      className={`mb-2 rounded-lg transition-all ${isExpanded ? "overflow-hidden bg-gray-500" : ""} ${isHighlighted ? "border-2 border-green-400 ring-2 ring-green-300/70" : ""}`}
       open={isExpanded}
       onToggle={(e) => setIsExpanded(e.currentTarget.open)}
     >
@@ -79,7 +73,7 @@ const Property: React.FC<IProperty> = ({ prop, propName }) => {
             onCopy={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              handleCopyProperty();
+              onCopy();
             }}
             onDelete={(e) => {
               e.preventDefault();

--- a/src/components/TDViewer/components/Property.tsx
+++ b/src/components/TDViewer/components/Property.tsx
@@ -11,7 +11,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 import React, { useContext, useState, useRef } from "react";
-import { Trash2, Copy } from "react-feather";
 import ediTDorContext from "../../../context/ediTDorContext";
 import {
   buildAttributeListObject,
@@ -23,100 +22,73 @@ import Form from "./Form";
 import AddFormDialog from "../../Dialogs/AddFormDialog";
 import AddFormElement from "../base/AddFormElement";
 import { copyAffordance } from "../../../utils/copyAffordance";
-
+import AffordanceButtons from "./AffordanceButtons";
 const alreadyRenderedKeys = ["title", "forms", "description"];
-
-const Property: React.FC<any> = (props) => {
+interface IProperty {
+  prop: any;
+  propName: string;
+}
+const Property: React.FC<IProperty> = ({ prop, propName }) => {
   const context = useContext(ediTDorContext);
   const [isExpanded, setIsExpanded] = useState(false);
-
   const addFormDialog = useRef<{ openModal: () => void }>(null);
-
-  const property = props.prop;
-  const forms = separateForms(structuredClone(property.forms));
-
+  const forms = separateForms(structuredClone(prop.forms));
   const attributeListObject = buildAttributeListObject(
-    { name: props.propName },
-    property,
+    { name: propName },
+    prop,
     alreadyRenderedKeys
   );
-
-  const handleDeletePropertyClicked = () => {
-    context.removeOneOfAKindReducer("properties", props.propName);
+  const handleDeleteProperty = () => {
+    context.removeOneOfAKindReducer("properties", propName);
   };
-
   const handleCopyProperty = () => {
-    try {
-      const { updatedTD, newName } = copyAffordance({
-        parsedTD: context.parsedTD,
-        section: "properties",
-        originalName: props.propName,
-        affordance: property,
-      });
-
-      context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
-      setIsExpanded(true);
-
-      setTimeout(() => {
-        document
-          .getElementById(`property-${newName}`)
-          ?.scrollIntoView({ behavior: "smooth", block: "center" });
-      }, 100);
-    } catch (e) {
-      console.error(e);
-    }
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: context.parsedTD,
+      section: "properties",
+      originalName: propName,
+      affordance: prop,
+    });
+    context.updateOfflineTD(JSON.stringify(updatedTD, null, 2));
+    setIsExpanded(true);
+    setTimeout(() => {
+      document
+        .getElementById(`property-${newName}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 100);
   };
 
   return (
     <details
-      id={`property-${props.propName}`}
-      className="mb-1"
+      id={`property-${propName}`}
+      className={`mb-2 ${isExpanded ? "overflow-hidden rounded-lg bg-gray-500" : ""}`}
       open={isExpanded}
       onToggle={() => setIsExpanded(!isExpanded)}
     >
-      <summary
-        className={`flex cursor-pointer items-center rounded-t-lg pl-2 text-xl font-bold text-white ${
-          isExpanded ? "bg-gray-500" : ""
-        }`}
-      >
-        <h3 className="flex-grow px-2">{property.title ?? props.propName}</h3>
-
+      <summary className="flex cursor-pointer items-center py-1 pl-2 text-xl font-bold text-white">
+        <h3 className="flex-grow px-2">{prop.title ?? propName}</h3>
         {isExpanded && (
-          <>
-            <button
-              className="flex h-10 w-10 items-center justify-center self-stretch bg-gray-400"
-              title="Copy property"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleCopyProperty();
-              }}
-            >
-              <Copy size={16} color="white" />
-            </button>
-
-            <button
-              className="flex h-10 w-10 items-center justify-center self-stretch rounded-bl-lg rounded-tr-lg bg-gray-400"
-              title="Delete property"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleDeletePropertyClicked();
-              }}
-            >
-              <Trash2 size={16} color="white" />
-            </button>
-          </>
+          <AffordanceButtons
+            copyTitle="Copy property"
+            deleteTitle="Delete property"
+            onCopy={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleCopyProperty();
+            }}
+            onDelete={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleDeleteProperty();
+            }}
+          />
         )}
       </summary>
-
-      <div className="mb-4 rounded-b-lg bg-gray-500 px-2 pb-4">
-        {property.description && (
+      <div className="px-2 pb-4">
+        {prop.description && (
           <div className="px-2 pb-2 text-lg text-gray-400">
-            {property.description}
+            {prop.description}
           </div>
         )}
-
         <ul className="list-disc pl-6 text-base text-gray-300">
           {Object.entries(attributeListObject).map(([k, v]) => (
             <li key={k}>
@@ -124,24 +96,20 @@ const Property: React.FC<any> = (props) => {
             </li>
           ))}
         </ul>
-
         <InfoIconWrapper tooltip={getFormsTooltipContent()} id="properties">
           <h4 className="text-lg font-bold text-white">Forms</h4>
         </InfoIconWrapper>
-
         <AddFormElement onClick={() => addFormDialog.current?.openModal()} />
-
         <AddFormDialog
           type="property"
-          interaction={property}
-          interactionName={props.propName}
+          interaction={prop}
+          interactionName={propName}
           ref={addFormDialog}
         />
-
         {forms.map((form, i) => (
           <Form
             key={`${i}-${form.href}`}
-            propName={props.propName}
+            propName={propName}
             form={form}
             interactionType="property"
           />

--- a/src/hooks/useCopiedAffordanceFocus.ts
+++ b/src/hooks/useCopiedAffordanceFocus.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+
+interface IUseCopiedAffordanceFocusOptions {
+  copiedToken?: number;
+  highlightDurationMs?: number;
+}
+
+interface IUseCopiedAffordanceFocusResult {
+  containerRef: React.RefObject<HTMLDetailsElement>;
+  isExpanded: boolean;
+  isHighlighted: boolean;
+  setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const useCopiedAffordanceFocus = ({
+  copiedToken,
+  highlightDurationMs = 3000,
+}: IUseCopiedAffordanceFocusOptions): IUseCopiedAffordanceFocusResult => {
+  const containerRef = useRef<HTMLDetailsElement>(null);
+  const highlightTimeoutRef = useRef<number | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isHighlighted, setIsHighlighted] = useState(false);
+
+  useEffect(() => {
+    if (copiedToken === undefined) {
+      return;
+    }
+
+    setIsExpanded(true);
+    setIsHighlighted(true);
+    containerRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+
+    if (highlightTimeoutRef.current !== null) {
+      window.clearTimeout(highlightTimeoutRef.current);
+    }
+
+    highlightTimeoutRef.current = window.setTimeout(() => {
+      setIsHighlighted(false);
+    }, highlightDurationMs);
+
+    return () => {
+      if (highlightTimeoutRef.current !== null) {
+        window.clearTimeout(highlightTimeoutRef.current);
+        highlightTimeoutRef.current = null;
+      }
+    };
+  }, [copiedToken, highlightDurationMs]);
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimeoutRef.current !== null) {
+        window.clearTimeout(highlightTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    containerRef,
+    isExpanded,
+    isHighlighted,
+    setIsExpanded,
+  };
+};

--- a/src/tests/InteractionSection.integration.test.tsx
+++ b/src/tests/InteractionSection.integration.test.tsx
@@ -1,0 +1,315 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import InteractionSection from "../components/TDViewer/components/InteractionSection";
+import ediTDorContext from "../context/ediTDorContext";
+import { editdorReducer } from "../context/editorReducers";
+import {
+  THING_DESCRIPTION_LAMP_JSON,
+  THING_DESCRIPTION_LAMP_V_STRING,
+  createContextValue,
+} from "./constants";
+
+vi.mock("@node-wot/browser-bundle", () => ({
+  Core: {
+    Servient: vi.fn().mockImplementation(() => ({
+      addClientFactory: vi.fn(),
+      start: vi.fn().mockResolvedValue({
+        consume: vi.fn(),
+      }),
+    })),
+  },
+  Http: {
+    HttpClientFactory: vi.fn(),
+  },
+}));
+
+vi.mock("@monaco-editor/react", () => ({
+  default: () => <div data-testid="monaco-editor" />,
+}));
+
+vi.mock("../components/Dialogs/AddActionDialog", async () => {
+  const React = await import("react");
+
+  const MockAddActionDialog = React.forwardRef((_props, ref) => {
+    React.useImperativeHandle(ref, () => ({ openModal: () => undefined }));
+    return null;
+  });
+
+  return { default: MockAddActionDialog };
+});
+
+vi.mock("../components/Dialogs/AddEventDialog", async () => {
+  const React = await import("react");
+
+  const MockAddEventDialog = React.forwardRef((_props, ref) => {
+    React.useImperativeHandle(ref, () => ({ openModal: () => undefined }));
+    return null;
+  });
+
+  return { default: MockAddEventDialog };
+});
+
+vi.mock("../components/Dialogs/AddPropertyDialog", async () => {
+  const React = await import("react");
+
+  const MockAddPropertyDialog = React.forwardRef((_props, ref) => {
+    React.useImperativeHandle(ref, () => ({ openModal: () => undefined }));
+    return null;
+  });
+
+  return { AddPropertyDialog: MockAddPropertyDialog };
+});
+
+vi.mock("../components/Dialogs/AddFormDialog", async () => {
+  const React = await import("react");
+
+  const MockAddFormDialog = React.forwardRef((_props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      openModal: () => undefined,
+      close: () => undefined,
+    }));
+    return null;
+  });
+
+  return { default: MockAddFormDialog };
+});
+
+vi.mock("../components/Dialogs/ErrorDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/Dialogs/DialogTemplate", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../components/TDViewer/components/EditProperties", () => ({
+  default: () => null,
+}));
+
+const createInitialEditorState = (): EditorState => {
+  const value = createContextValue({
+    offlineTD: THING_DESCRIPTION_LAMP_V_STRING,
+    parsedTD: structuredClone(THING_DESCRIPTION_LAMP_JSON),
+    isValidJSON: true,
+    name: THING_DESCRIPTION_LAMP_JSON.title,
+  });
+
+  return {
+    offlineTD: value.offlineTD,
+    isValidJSON: value.isValidJSON,
+    parsedTD: value.parsedTD,
+    isModified: value.isModified,
+    name: value.name,
+    fileHandle: value.fileHandle,
+    linkedTd: value.linkedTd,
+    validationMessage: value.validationMessage,
+    northboundConnection: value.northboundConnection,
+    contributeCatalog: value.contributeCatalog,
+  };
+};
+
+const TestContextProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, dispatch] = React.useReducer(
+    editdorReducer,
+    undefined,
+    createInitialEditorState
+  );
+
+  const contextValue = createContextValue({
+    offlineTD: state.offlineTD,
+    isValidJSON: state.isValidJSON,
+    parsedTD: state.parsedTD,
+    isModified: state.isModified,
+    name: state.name,
+    fileHandle: state.fileHandle,
+    linkedTd: state.linkedTd,
+    validationMessage: state.validationMessage,
+    northboundConnection: state.northboundConnection,
+    contributeCatalog: state.contributeCatalog,
+    updateOfflineTD: (offlineTD: string) => {
+      dispatch({ type: "UPDATE_OFFLINE_TD", offlineTD });
+    },
+    removeOneOfAKindReducer: (
+      kind: "properties" | "actions" | "events" | string,
+      oneOfAKindName: string
+    ) => {
+      dispatch({ type: "REMOVE_ONE_OF_A_KIND_FROM_TD", kind, oneOfAKindName });
+    },
+  });
+
+  return (
+    <ediTDorContext.Provider value={contextValue}>
+      {children}
+    </ediTDorContext.Provider>
+  );
+};
+
+const OfflineTdProbe: React.FC = () => {
+  const { offlineTD } = React.useContext(ediTDorContext);
+
+  return <pre data-testid="offline-td">{offlineTD}</pre>;
+};
+
+const getOfflineTdJson = () => {
+  const offlineTd = screen.getByTestId("offline-td").textContent ?? "{}";
+
+  return JSON.parse(offlineTd);
+};
+
+describe("InteractionSection affordance flows", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  test("copies a property, opens the new affordance, and highlights it", async () => {
+    render(
+      <TestContextProvider>
+        <InteractionSection interaction="Properties" />
+        <OfflineTdProbe />
+      </TestContextProvider>
+    );
+
+    fireEvent.click(screen.getByText("status"));
+    const copyButton = await screen.findByRole("button", {
+      name: /copy property/i,
+    });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      const td = getOfflineTdJson();
+
+      expect(td.properties).toHaveProperty("status");
+      expect(td.properties).toHaveProperty("status_copy");
+      expect(td.actions).toHaveProperty("toggle");
+      expect(td.events).toHaveProperty("overheating");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("status_copy")).toBeInTheDocument();
+    });
+
+    const copiedAffordance = document.getElementById("property-status_copy");
+
+    expect(copiedAffordance).toHaveAttribute("open");
+    expect(copiedAffordance).toHaveClass("border-green-400");
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  test("copies an action, opens the new affordance, and updates parsed offlineTd", async () => {
+    render(
+      <TestContextProvider>
+        <InteractionSection interaction="Actions" />
+        <OfflineTdProbe />
+      </TestContextProvider>
+    );
+
+    fireEvent.click(screen.getByText("toggle"));
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /copy action/i })
+    );
+
+    await waitFor(() => {
+      const td = getOfflineTdJson();
+
+      expect(td.actions).toHaveProperty("toggle");
+      expect(td.actions).toHaveProperty("toggle_copy");
+      expect(td.properties).toHaveProperty("status");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("toggle_copy")).toBeInTheDocument();
+    });
+
+    const copiedAffordance = document.getElementById("action-toggle_copy");
+
+    expect(copiedAffordance).toHaveAttribute("open");
+    expect(copiedAffordance).toHaveClass("border-green-400");
+  });
+
+  test("hides and shows the copy affordance button with property expansion state", async () => {
+    render(
+      <TestContextProvider>
+        <InteractionSection interaction="Properties" />
+      </TestContextProvider>
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /copy property/i })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("status"));
+
+    expect(
+      await screen.findByRole("button", { name: /copy property/i })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("status"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /copy property/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("hides and shows the delete affordance button with property expansion state", async () => {
+    render(
+      <TestContextProvider>
+        <InteractionSection interaction="Properties" />
+      </TestContextProvider>
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /delete property/i })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("status"));
+
+    expect(
+      await screen.findByRole("button", { name: /delete property/i })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("status"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /delete property/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("deletes a property and updates offlineTd", async () => {
+    render(
+      <TestContextProvider>
+        <InteractionSection interaction="Properties" />
+        <OfflineTdProbe />
+      </TestContextProvider>
+    );
+
+    fireEvent.click(screen.getByText("status"));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /delete property/i })
+    );
+
+    await waitFor(() => {
+      const td = getOfflineTdJson();
+
+      expect(td.properties).not.toHaveProperty("status");
+      expect(td.actions).toHaveProperty("toggle");
+      expect(td.events).toHaveProperty("overheating");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("status")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/types/form.d.ts
+++ b/src/types/form.d.ts
@@ -9,7 +9,7 @@
  * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
- ********************************************************************************/ ß;
+ ********************************************************************************/
 import { ThingDescription } from "wot-thing-description-types";
 
 type ServientCallback = (
@@ -26,14 +26,31 @@ export interface IFormConfigurations {
   callback: ServientCallback | null;
 }
 
-interface IFormProps {
+export interface IInteractionForm {
   href: string;
-  op: string | string[];
-  propName: string;
-  actualIndex: number;
+  op?: string | string[];
+  contentType?: string;
+  [key: string]: unknown;
 }
 
-type OpKeys =
+export interface IExplicitForm extends IInteractionForm {
+  op: string | string[];
+}
+
+export interface IInteractionAffordance {
+  title?: string;
+  description?: string;
+  type?: string;
+  forms?: IInteractionForm[];
+  [key: string]: unknown;
+}
+
+export type IFormProps = IInteractionForm & {
+  actualIndex: number;
+  [key: string]: unknown;
+};
+
+export type OpKeys =
   | "readproperty"
   | "writeproperty"
   | "observeproperty"

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -55,4 +55,7 @@ declare global {
     quality?: number;
   }
 }
+
+export type InteractionKey = "actions" | "properties" | "events";
+
 export {};

--- a/src/utils/copyAffordance.test.ts
+++ b/src/utils/copyAffordance.test.ts
@@ -1,0 +1,184 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { describe, expect, test } from "vitest";
+import { copyAffordance } from "./copyAffordance";
+
+describe("copyAffordance", () => {
+  test("creates a copy with a unique name appended with '_copy'", () => {
+    const td = {
+      actions: {
+        reset: {
+          title: "Reset Sensor",
+          forms: [],
+        },
+      },
+    };
+
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: td,
+      section: "actions",
+      originalName: "reset",
+      affordance: td.actions.reset,
+    });
+
+    expect(newName).toBe("reset_copy");
+    expect(updatedTD.actions[newName]).toBeDefined();
+    expect(updatedTD.actions[newName].title).toBe("Reset Sensor copy");
+  });
+
+  test("increments name suffix when '_copy' already exists", () => {
+    const resetAffordance = { title: "Reset", forms: [] };
+    const td = {
+      actions: {
+        reset: resetAffordance,
+        reset_copy: { title: "Reset copy", forms: [] },
+      },
+    };
+
+    const { newName } = copyAffordance({
+      parsedTD: td,
+      section: "actions",
+      originalName: "reset",
+      affordance: resetAffordance,
+    });
+
+    expect(newName).toBe("reset_copy_1");
+  });
+
+  test("increments counter further when multiple copies already exist", () => {
+    const resetAffordance = { title: "Reset", forms: [] };
+    const td = {
+      actions: {
+        reset: resetAffordance,
+        reset_copy: { title: "Reset copy", forms: [] },
+        reset_copy_1: { title: "Reset copy 1", forms: [] },
+      },
+    };
+
+    const { newName } = copyAffordance({
+      parsedTD: td,
+      section: "actions",
+      originalName: "reset",
+      affordance: resetAffordance,
+    });
+
+    expect(newName).toBe("reset_copy_2");
+  });
+
+  test("does not append 'copy' to title when affordance has no title", () => {
+    const affordance = { forms: [] };
+    const td = {
+      properties: {
+        temperature: affordance,
+      },
+    };
+
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: td,
+      section: "properties",
+      originalName: "temperature",
+      affordance,
+    });
+
+    expect(newName).toBe("temperature_copy");
+    expect(updatedTD.properties[newName].title).toBeUndefined();
+  });
+
+  test("inserts the copied affordance immediately after the original", () => {
+    const tdAffordance = { title: "Toggle", forms: [] };
+    const td = {
+      actions: {
+        start: { title: "Start", forms: [] },
+        toggle: tdAffordance,
+        stop: { title: "Stop", forms: [] },
+      },
+    };
+
+    const { updatedTD } = copyAffordance({
+      parsedTD: td,
+      section: "actions",
+      originalName: "toggle",
+      affordance: tdAffordance,
+    });
+
+    const keys = Object.keys(updatedTD.actions);
+    const originalIndex = keys.indexOf("toggle");
+    const copyIndex = keys.indexOf("toggle_copy");
+
+    expect(copyIndex).toBe(originalIndex + 1);
+  });
+
+  test("deep clones the affordance so original is not mutated", () => {
+    const affordance = { title: "Read", forms: [{ href: "/read" }] };
+    const td = {
+      properties: {
+        status: affordance,
+      },
+    };
+
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: td,
+      section: "properties",
+      originalName: "status",
+      affordance,
+    });
+
+    // Mutating the copy should not affect the original
+    updatedTD.properties[newName].forms[0].href = "/mutated";
+    expect(affordance.forms[0].href).toBe("/read");
+  });
+
+  test("supports 'events' section", () => {
+    const eventAffordance = { title: "Overheat Alert", forms: [] };
+    const td = {
+      events: {
+        overheat: eventAffordance,
+      },
+    };
+
+    const { updatedTD, newName } = copyAffordance({
+      parsedTD: td,
+      section: "events",
+      originalName: "overheat",
+      affordance: eventAffordance,
+    });
+
+    expect(newName).toBe("overheat_copy");
+    expect(updatedTD.events[newName].title).toBe("Overheat Alert copy");
+  });
+
+  test("throws an error when parsedTD is null", () => {
+    expect(() =>
+      copyAffordance({
+        parsedTD: null,
+        section: "actions",
+        originalName: "reset",
+        affordance: {},
+      })
+    ).toThrow('TD or section "actions" missing');
+  });
+
+  test("throws an error when the section does not exist in parsedTD", () => {
+    const td = { properties: {} };
+
+    expect(() =>
+      copyAffordance({
+        parsedTD: td,
+        section: "actions",
+        originalName: "reset",
+        affordance: {},
+      })
+    ).toThrow('TD or section "actions" missing');
+  });
+});

--- a/src/utils/copyAffordance.ts
+++ b/src/utils/copyAffordance.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+type Section = "actions" | "properties" | "events";
+
+interface CopyAffordanceParams {
+  parsedTD: any;
+  section: Section;
+  originalName: string;
+  affordance: any;
+}
+
+export function copyAffordance({
+  parsedTD,
+  section,
+  originalName,
+  affordance,
+}: CopyAffordanceParams): { updatedTD: any; newName: string } {
+  if (!parsedTD || !parsedTD[section]) {
+    throw new Error(`TD or section "${section}" missing`);
+  }
+
+  const originalSection = parsedTD[section];
+
+  
+  let newName = `${originalName}_copy`;
+  let counter = 1;
+
+  while (originalSection[newName]) {
+    newName = `${originalName}_copy_${counter++}`;
+  }
+
+  const copiedAffordance = structuredClone(affordance);
+
+  if (copiedAffordance.title) {
+    copiedAffordance.title = `${copiedAffordance.title} copy`;
+  }
+
+  const entries = Object.entries(originalSection);
+  const newEntries: [string, any][] = [];
+
+  for (const [key, value] of entries) {
+    newEntries.push([key, value]);
+
+    if (key === originalName) {
+      newEntries.push([newName, copiedAffordance]);
+    }
+  }
+
+  const updatedSection = Object.fromEntries(newEntries);
+
+
+  const updatedTD = {
+    ...parsedTD,
+    [section]: updatedSection,
+  };
+
+  return { updatedTD, newName };
+}

--- a/src/utils/copyAffordance.ts
+++ b/src/utils/copyAffordance.ts
@@ -12,12 +12,11 @@
  ********************************************************************************/
 
 import test from "node:test";
-
-type Section = "actions" | "properties" | "events";
+import type { InteractionKey } from "../types/global";
 
 interface CopyAffordanceParams {
   parsedTD: any;
-  section: Section;
+  section: InteractionKey;
   originalName: string;
   affordance: any;
 }

--- a/src/utils/copyAffordance.ts
+++ b/src/utils/copyAffordance.ts
@@ -32,7 +32,6 @@ export function copyAffordance({
 
   const originalSection = parsedTD[section];
 
-  
   let newName = `${originalName}_copy`;
   let counter = 1;
 
@@ -58,7 +57,6 @@ export function copyAffordance({
   }
 
   const updatedSection = Object.fromEntries(newEntries);
-
 
   const updatedTD = {
     ...parsedTD,

--- a/src/utils/copyAffordance.ts
+++ b/src/utils/copyAffordance.ts
@@ -11,6 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
+import test from "node:test";
+
 type Section = "actions" | "properties" | "events";
 
 interface CopyAffordanceParams {

--- a/src/utils/copyAffordance.ts
+++ b/src/utils/copyAffordance.ts
@@ -10,8 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-
-import test from "node:test";
 import type { InteractionKey } from "../types/global";
 
 interface CopyAffordanceParams {

--- a/src/utils/tdOperations.ts
+++ b/src/utils/tdOperations.ts
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { ExplicitForm } from "components/Dialogs/AddFormDialog";
 import { direction } from "direction";
+import type { ExplicitForm, FormProps, InteractionForm } from "types/form";
 
 /**
  * @param {Object} td
@@ -69,26 +69,32 @@ export const buildAttributeListObject = (
  * Converts Forms that have an array as the "op" value into multiple separate Forms
  * which only have a string as "op" value.
  */
-export const separateForms = (forms) => {
-  if (forms === undefined && !forms) {
+export const separateForms = (
+  forms: InteractionForm[] | undefined
+): FormProps[] => {
+  if (forms === undefined || forms === null) {
     return [];
   }
 
-  const newForms = [];
+  const newForms: FormProps[] = [];
 
   for (let i = 0; i < forms.length; i++) {
     const form = forms[i];
 
     if (!Array.isArray(form.op)) {
-      form.actualIndex = i;
-      newForms.push(form);
+      newForms.push({
+        ...form,
+        actualIndex: i,
+      });
       continue;
     }
 
     for (let j = 0; j < form.op.length; j++) {
-      const temp = { ...form };
-      temp.op = form.op[j];
-      temp.actualIndex = i;
+      const temp: FormProps = {
+        ...form,
+        op: form.op[j],
+        actualIndex: i,
+      };
       newForms.push(temp);
     }
   }
@@ -110,7 +116,7 @@ export const checkIfLinkIsInItem = (link, itemToCheck) => {
 
 export const checkIfFormIsInItem = (
   form: ExplicitForm,
-  itemToCheck: { forms: ExplicitForm[] }
+  itemToCheck: { forms: InteractionForm[] }
 ): boolean => {
   for (const element of itemToCheck.forms) {
     if (typeof element.op === "undefined") {
@@ -148,7 +154,7 @@ export const checkIfFormIsInItem = (
 
 export const checkIfFormIsInElement = (
   form: ExplicitForm & { op: string },
-  element: ExplicitForm
+  element: InteractionForm
 ): boolean => {
   if (typeof element.op === "undefined") {
     return false;


### PR DESCRIPTION
Fixes #57

This PR adds a copy button for Thing Description affordances (actions, properties, and events) in the visual editor.

Users can now duplicate similar affordances directly from the UI without switching to the JSON editor, improving usability and workflow efficiency.
