### PR TITLE
fix: allow adding top level form when forms is missing

### DIFF
--- a/src/context/editorReducers.ts
+++ b/src/context/editorReducers.ts
@@ -286,11 +286,11 @@ const addFormReducer = (
       return state;
     }
 
-    if (!td.forms) {
-      td.forms = undefined;
+    if (!Array.isArray(td.forms)) {
+      td.forms = [];
     }
 
-    td.forms?.push(form);
+    td.forms.push(form);
     return { ...state, offlineTD: JSON.stringify(td, null, 2), parsedTD: td };
   }
 


### PR DESCRIPTION
Fixes #177

Ensure that adding a top-level form works even when the TD does not yet
contain a `forms` array.

The fix initializes `forms: []` before adding a new form, preventing the
previous silent no-op behavior.

Verified locally:
- Forms can be added when `forms` is missing
- Existing behavior remains unchanged
