### PR TITLE
feat(settings): add JSON editor indentation option (2 or 4 spaces)

### DIFF
--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -19,6 +19,7 @@ export interface SettingsData {
   northboundUrl: string;
   southboundUrl: string;
   pathToValue: string;
+  jsonIndentation: 2 | 4;
 }
 
 export interface SettingsErrors {
@@ -39,6 +40,7 @@ const Settings: React.FC<SettingsProps> = ({
     northboundUrl: "",
     southboundUrl: "",
     pathToValue: "/",
+    jsonIndentation: 2,
   },
   onChange,
   hideTitle = false,
@@ -126,6 +128,36 @@ const Settings: React.FC<SettingsProps> = ({
     },
     []
   );
+
+  const handleJsonIndentationChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const parsed = Number(e.target.value);
+      const value: 2 | 4 = parsed === 4 ? 4 : 2;
+      setData((prev) => ({ ...prev, jsonIndentation: value }));
+    },
+    []
+  );
+
+  <div className="my-4 rounded-md bg-black bg-opacity-80 p-2">
+    <h1 className="font-bold">JSON Editor</h1>
+    <div className="px-4">
+      <label
+        htmlFor="json-indentation-select"
+        className="mb-1 block text-sm text-gray-300"
+      >
+        Space indentation
+      </label>
+      <select
+        id="json-indentation-select"
+        value={data.jsonIndentation}
+        onChange={handleJsonIndentationChange}
+        className="w-full rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm"
+      >
+        <option value={2}>2 spaces</option>
+        <option value={4}>4 spaces</option>
+      </select>
+    </div>
+  </div>;
 
   return (
     <div className={className}>

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -10,10 +10,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import InfoIconWrapper from "../base/InfoIconWrapper";
 import TextField from "../base/TextField";
 import { isValidUrl } from "../../utils/strings";
+import EdiTDorContext from "../../context/ediTDorContext";
 
 export interface SettingsData {
   northboundUrl: string;
@@ -46,6 +47,7 @@ const Settings: React.FC<SettingsProps> = ({
   hideTitle = false,
   className = "",
 }) => {
+  const context = useContext(EdiTDorContext);
   const [data, setData] = useState<SettingsData>(initialData);
   const [errors, setErrors] = useState<SettingsErrors>({
     northboundUrl: "",
@@ -54,8 +56,11 @@ const Settings: React.FC<SettingsProps> = ({
   });
 
   useEffect(() => {
-    setData(initialData);
-  }, [initialData]);
+    setData((prev) => ({
+      ...prev,
+      jsonIndentation: context.jsonIndentation,
+    }));
+  }, [context.jsonIndentation]);
 
   useEffect(() => {
     if (onChange) {
@@ -134,8 +139,9 @@ const Settings: React.FC<SettingsProps> = ({
       const parsed = Number(e.target.value);
       const value: 2 | 4 = parsed === 4 ? 4 : 2;
       setData((prev) => ({ ...prev, jsonIndentation: value }));
+      context.updateJsonIndentation(value);
     },
-    []
+    [context]
   );
 
   return (

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -138,29 +138,29 @@ const Settings: React.FC<SettingsProps> = ({
     []
   );
 
-  <div className="my-4 rounded-md bg-black bg-opacity-80 p-2">
-    <h1 className="font-bold">JSON Editor</h1>
-    <div className="px-4">
-      <label
-        htmlFor="json-indentation-select"
-        className="mb-1 block text-sm text-gray-300"
-      >
-        Space indentation
-      </label>
-      <select
-        id="json-indentation-select"
-        value={data.jsonIndentation}
-        onChange={handleJsonIndentationChange}
-        className="w-full rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm"
-      >
-        <option value={2}>2 spaces</option>
-        <option value={4}>4 spaces</option>
-      </select>
-    </div>
-  </div>;
-
   return (
     <div className={className}>
+      <div className="my-4 rounded-md bg-black bg-opacity-80 p-2">
+        {!hideTitle && <h1 className="font-bold">JSON Editor</h1>}
+        <div className="px-4">
+          <label
+            htmlFor="json-indentation-select"
+            className="mb-1 block text-sm text-gray-300"
+          >
+            Space indentation
+          </label>
+          <select
+            id="json-indentation-select"
+            value={data.jsonIndentation}
+            onChange={handleJsonIndentationChange}
+            className="w-full rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm"
+          >
+            <option value={2}>2 spaces</option>
+            <option value={4}>4 spaces</option>
+          </select>
+        </div>
+      </div>
+
       <div className="rounded-md bg-black bg-opacity-80 p-2">
         {!hideTitle && (
           <h1 className="font-bold">Third Party Service Configuration</h1>

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -15,6 +15,7 @@ import InfoIconWrapper from "../base/InfoIconWrapper";
 import TextField from "../base/TextField";
 import { isValidUrl } from "../../utils/strings";
 import EdiTDorContext from "../../context/ediTDorContext";
+import Dropdown from "../base/Dropdown";
 
 export interface SettingsData {
   northboundUrl: string;
@@ -149,21 +150,14 @@ const Settings: React.FC<SettingsProps> = ({
       <div className="my-4 rounded-md bg-black bg-opacity-80 p-2">
         {!hideTitle && <h1 className="font-bold">JSON Editor</h1>}
         <div className="px-4">
-          <label
-            htmlFor="json-indentation-select"
-            className="mb-1 block text-sm text-gray-300"
-          >
-            Space indentation
-          </label>
-          <select
+          <Dropdown
             id="json-indentation-select"
-            value={data.jsonIndentation}
+            label="Space indentation"
+            value={String(data.jsonIndentation)}
             onChange={handleJsonIndentationChange}
-            className="w-full rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-white focus:border-blue-500 focus:outline-none sm:text-sm"
-          >
-            <option value={2}>2 spaces</option>
-            <option value={4}>4 spaces</option>
-          </select>
+            options={["2", "4"]}
+            className="w-full"
+          />
         </div>
       </div>
 

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -21,7 +21,6 @@ export interface SettingsData {
   northboundUrl: string;
   southboundUrl: string;
   pathToValue: string;
-  jsonIndentation: 2 | 4;
 }
 
 export interface SettingsErrors {
@@ -42,7 +41,6 @@ const Settings: React.FC<SettingsProps> = ({
     northboundUrl: "",
     southboundUrl: "",
     pathToValue: "/",
-    jsonIndentation: 2,
   },
   onChange,
   hideTitle = false,
@@ -56,12 +54,6 @@ const Settings: React.FC<SettingsProps> = ({
     pathToValue: "",
   });
 
-  useEffect(() => {
-    setData((prev) => ({
-      ...prev,
-      jsonIndentation: context.jsonIndentation,
-    }));
-  }, [context.jsonIndentation]);
 
   useEffect(() => {
     if (onChange) {
@@ -139,7 +131,6 @@ const Settings: React.FC<SettingsProps> = ({
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const parsed = Number(e.target.value);
       const value: 2 | 4 = parsed === 4 ? 4 : 2;
-      setData((prev) => ({ ...prev, jsonIndentation: value }));
       context.updateJsonIndentation(value);
     },
     [context]
@@ -153,7 +144,7 @@ const Settings: React.FC<SettingsProps> = ({
           <Dropdown
             id="json-indentation-select"
             label="Space indentation"
-            value={String(data.jsonIndentation)}
+            value={String(context.jsonIndentation)}
             onChange={handleJsonIndentationChange}
             options={["2", "4"]}
             className="w-full"

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -54,7 +54,6 @@ const Settings: React.FC<SettingsProps> = ({
     pathToValue: "",
   });
 
-
   useEffect(() => {
     if (onChange) {
       const isValid =

--- a/src/components/Editor/JsonEditor.tsx
+++ b/src/components/Editor/JsonEditor.tsx
@@ -201,8 +201,10 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ editorRef }) => {
 
       if (formatted !== editorText) {
         context.updateOfflineTD(formatted);
+        setLocalTextState(formatted);
       } else {
         context.updateOfflineTD(editorText);
+        setLocalTextState(editorText);
       }
 
       context.updateValidationMessage(validate);
@@ -279,6 +281,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ editorRef }) => {
             lineDecorationsWidth: 20,
             tabSize: jsonIndentation,
             insertSpaces: true,
+            detectIndentation: false,
           }}
           theme={"vs-" + "dark"}
           language="json"

--- a/src/components/Editor/JsonEditor.tsx
+++ b/src/components/Editor/JsonEditor.tsx
@@ -27,13 +27,6 @@ import { IValidationMessage } from "../../types/context";
 type SchemaMapMessage = Map<string, Record<string, unknown>>;
 
 // List of all Options can be found here: https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IStandaloneEditorConstructionOptions.html
-const editorOptions: editor.IStandaloneEditorConstructionOptions = {
-  selectOnLineNumbers: true,
-  automaticLayout: true,
-  lineDecorationsWidth: 20,
-  tabSize: 2,
-  insertSpaces: true,
-};
 
 // delay function that executes the callback once it hasn't been called for
 // at least x ms.

--- a/src/components/Editor/JsonEditor.tsx
+++ b/src/components/Editor/JsonEditor.tsx
@@ -209,8 +209,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({ editorRef }) => {
       validate.report.json = "failed";
       context.updateValidationMessage(validate);
       setLocalTextState(editorText);
-
-      delay(messageWorkers, editorText, 500);
+      delay(messageWorkers, editorText ?? "", 500);
     }
   };
 

--- a/src/components/Editor/JsonEditor.tsx
+++ b/src/components/Editor/JsonEditor.tsx
@@ -47,7 +47,7 @@ interface JsonSchemaEntry {
 const JsonEditor: React.FC<JsonEditorProps> = ({ editorRef }) => {
   const context = useContext(ediTDorContext);
 
-  const jsonIndentation = context.settings?.jsonIndentation ?? 2;
+  const jsonIndentation = context.jsonIndentation ?? 2;
   const [schemas] = useState<JsonSchemaEntry[]>([]);
   const [proxy, setProxy] = useState<any>(undefined);
   const editorInstance = useRef<editor.IStandaloneCodeEditor | null>(null);

--- a/src/components/base/Dropdown.tsx
+++ b/src/components/base/Dropdown.tsx
@@ -17,6 +17,8 @@ interface IDropdownProps {
   id: string;
   label: string;
   options: string[];
+  value?: string;
+  onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   className?: string;
 }
 
@@ -33,6 +35,8 @@ const Dropdown: React.FC<IDropdownProps> = (props) => {
         <select
           className="block w-full appearance-none rounded border-2 border-gray-600 bg-gray-600 px-4 py-3 pr-8 leading-tight text-white focus:border-blue-500 focus:outline-none"
           id={props.id}
+          value={props.value}
+          onChange={props.onChange}
         >
           {props.options.map((e) => {
             return <option key={e}>{e}</option>;

--- a/src/context/GlobalState.tsx
+++ b/src/context/GlobalState.tsx
@@ -28,7 +28,7 @@ export const UPDATE_VALIDATION_MESSAGE = "UPDATE_VALIDATION_MESSAGE";
 export const UPDATE_NORTHBOUND_CONNECTION = "UPDATE_NORTHBOUND_CONNECTION";
 export const UPDATE_CONTRIBUTE_CATALOG = "UPDATE_CONTRIBUTE_CATALOG";
 export const UPDATE_BACKGROUND_TM = "UPDATE_BACKGROUND_TM";
-export const UPDATE_SETTINGS = "UPDATE_SETTINGS";
+export const UPDATE_JSON_INDENTATION = "UPDATE_JSON_INDENTATION";
 
 interface IGlobalStateProps {
   children: ReactNode;
@@ -94,12 +94,7 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
       nameRepository: "",
       dynamicValues: {},
     },
-    settings: {
-      northboundUrl: "",
-      southboundUrl: "",
-      pathToValue: "/",
-      jsonIndentation: 2,
-    },
+    jsonIndentation: 2,
   });
 
   const updateOfflineTD = (offlineTD: string) => {
@@ -184,10 +179,10 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
     });
   };
 
-  const updateSettings = (settings: SettingsData) => {
+  const updateJsonIndentation = (value: 2 | 4) => {
     dispatch({
-      type: UPDATE_SETTINGS,
-      settings,
+      type: UPDATE_JSON_INDENTATION,
+      value,
     });
   };
 
@@ -204,8 +199,8 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         validationMessage: editdorState.validationMessage,
         northboundConnection: editdorState.northboundConnection,
         contributeCatalog: editdorState.contributeCatalog,
-        settings: editdorState.settings,
-        updateSettings,
+        jsonIndentation: editdorState.jsonIndentation,
+        updateJsonIndentation,
         updateOfflineTD,
         updateIsModified,
         setFileHandle,

--- a/src/context/GlobalState.tsx
+++ b/src/context/GlobalState.tsx
@@ -28,6 +28,7 @@ export const UPDATE_VALIDATION_MESSAGE = "UPDATE_VALIDATION_MESSAGE";
 export const UPDATE_NORTHBOUND_CONNECTION = "UPDATE_NORTHBOUND_CONNECTION";
 export const UPDATE_CONTRIBUTE_CATALOG = "UPDATE_CONTRIBUTE_CATALOG";
 export const UPDATE_BACKGROUND_TM = "UPDATE_BACKGROUND_TM";
+export const UPDATE_SETTINGS = "UPDATE_SETTINGS";
 
 interface IGlobalStateProps {
   children: ReactNode;
@@ -92,6 +93,12 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
       tmCatalogEndpoint: "",
       nameRepository: "",
       dynamicValues: {},
+    },
+    settings: {
+      northboundUrl: "",
+      southboundUrl: "",
+      pathToValue: "/",
+      jsonIndentation: 2,
     },
   });
 
@@ -177,6 +184,13 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
     });
   };
 
+  const updateSettings = (settings: SettingsData) => {
+    dispatch({
+      type: UPDATE_SETTINGS,
+      settings,
+    });
+  };
+
   return (
     <EdiTDorContext.Provider
       value={{
@@ -190,6 +204,8 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         validationMessage: editdorState.validationMessage,
         northboundConnection: editdorState.northboundConnection,
         contributeCatalog: editdorState.contributeCatalog,
+        settings: editdorState.settings,
+        updateSettings,
         updateOfflineTD,
         updateIsModified,
         setFileHandle,

--- a/src/context/GlobalState.tsx
+++ b/src/context/GlobalState.tsx
@@ -200,7 +200,6 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         northboundConnection: editdorState.northboundConnection,
         contributeCatalog: editdorState.contributeCatalog,
         jsonIndentation: editdorState.jsonIndentation,
-        updateJsonIndentation,
         updateOfflineTD,
         updateIsModified,
         setFileHandle,
@@ -213,6 +212,7 @@ const GlobalState: React.FC<IGlobalStateProps> = ({ children }) => {
         updateValidationMessage,
         updateNorthboundConnection,
         updateContributeCatalog,
+        updateJsonIndentation,
       }}
     >
       {children}

--- a/src/context/ediTDorContext.ts
+++ b/src/context/ediTDorContext.ts
@@ -69,6 +69,7 @@ const defaultContext: IEdiTDorContext = {
     nameRepository: "",
     dynamicValues: {},
   },
+  jsonIndentation: 2,
 
   updateOfflineTD: () => {},
   updateIsModified: () => {},
@@ -82,6 +83,7 @@ const defaultContext: IEdiTDorContext = {
   updateValidationMessage: () => {},
   updateNorthboundConnection: () => {},
   updateContributeCatalog: () => {},
+  updateJsonIndentation: () => {},
 };
 
 const ediTDorContext = React.createContext<IEdiTDorContext>(defaultContext);

--- a/src/context/editorReducers.ts
+++ b/src/context/editorReducers.ts
@@ -10,7 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import { SettingsData } from "../components/App/Settings";
 import {
   ADD_FORM_TO_TD,
   ADD_LINKED_TD,
@@ -24,7 +23,7 @@ import {
   UPDATE_VALIDATION_MESSAGE,
   UPDATE_NORTHBOUND_CONNECTION,
   UPDATE_CONTRIBUTE_CATALOG,
-  UPDATE_SETTINGS,
+  UPDATE_JSON_INDENTATION,
 } from "./GlobalState";
 import type {
   ThingDescription,
@@ -72,8 +71,8 @@ export const editdorReducer = (
       return updateNorthboundConnection(action.northboundConnection, state);
     case UPDATE_CONTRIBUTE_CATALOG:
       return updateContributeCatalog(action.contributeCatalog, state);
-    case UPDATE_SETTINGS:
-      return updateSettingsReducer(action.settings, state);
+    case UPDATE_JSON_INDENTATION:
+      return updateJsonIndentationReducer(action.value, state);
     default:
       return state;
   }
@@ -369,12 +368,12 @@ const updateContributeCatalog = (
 ): EditorState => {
   return { ...state, contributeCatalog };
 };
-const updateSettingsReducer = (
-  settings: SettingsData,
+const updateJsonIndentationReducer = (
+  jsonIndentation: 2 | 4,
   state: EditorState
 ): EditorState => {
   return {
     ...state,
-    settings,
+    jsonIndentation,
   };
 };

--- a/src/context/editorReducers.ts
+++ b/src/context/editorReducers.ts
@@ -10,6 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
+import { SettingsData } from "../components/App/Settings";
 import {
   ADD_FORM_TO_TD,
   ADD_LINKED_TD,
@@ -23,6 +24,7 @@ import {
   UPDATE_VALIDATION_MESSAGE,
   UPDATE_NORTHBOUND_CONNECTION,
   UPDATE_CONTRIBUTE_CATALOG,
+  UPDATE_SETTINGS,
 } from "./GlobalState";
 import type {
   ThingDescription,
@@ -70,6 +72,8 @@ export const editdorReducer = (
       return updateNorthboundConnection(action.northboundConnection, state);
     case UPDATE_CONTRIBUTE_CATALOG:
       return updateContributeCatalog(action.contributeCatalog, state);
+    case UPDATE_SETTINGS:
+      return updateSettingsReducer(action.settings, state);
     default:
       return state;
   }
@@ -364,4 +368,13 @@ const updateContributeCatalog = (
   state: EditorState
 ): EditorState => {
   return { ...state, contributeCatalog };
+};
+const updateSettingsReducer = (
+  settings: SettingsData,
+  state: EditorState
+): EditorState => {
+  return {
+    ...state,
+    settings,
+  };
 };

--- a/src/types/context.d.ts
+++ b/src/types/context.d.ts
@@ -13,7 +13,8 @@ declare global {
 
     northboundConnection: INorthboundConnection;
     contributeCatalog: IContributeCatalog;
-    settings: SettingsData;
+    jsonIndentation: 2 | 4;
+    updateJsonIndentation: (value: 2 | 4) => void;
 
     // Callback functions
     updateOfflineTD: (td: string) => void;
@@ -143,7 +144,7 @@ declare global {
         type: "UPDATE_CONTRIBUTE_CATALOG";
         contributeCatalog: IContributeCatalog;
       }
-    | { type: "UPDATE_SETTINGS"; settings: SettingsData };
+    | { type: "UPDATE_JSON_INDENTATION"; value: 2 | 4 };
 
   declare type Validation = "VALID" | "INVALID" | "VALIDATING" | null;
   declare type ActiveSection =

--- a/src/types/context.d.ts
+++ b/src/types/context.d.ts
@@ -13,6 +13,7 @@ declare global {
 
     northboundConnection: INorthboundConnection;
     contributeCatalog: IContributeCatalog;
+    settings: SettingsData;
 
     // Callback functions
     updateOfflineTD: (td: string) => void;
@@ -141,7 +142,8 @@ declare global {
     | {
         type: "UPDATE_CONTRIBUTE_CATALOG";
         contributeCatalog: IContributeCatalog;
-      };
+      }
+    | { type: "UPDATE_SETTINGS"; settings: SettingsData };
 
   declare type Validation = "VALID" | "INVALID" | "VALIDATING" | null;
   declare type ActiveSection =
@@ -157,6 +159,7 @@ declare global {
     northboundUrl: string;
     southboundUrl: string;
     pathToValue: string;
+    jsonIndentation: 2 | 4;
   }
 
   // Define the shape of the state

--- a/src/types/context.d.ts
+++ b/src/types/context.d.ts
@@ -108,6 +108,7 @@ declare global {
     | "updateValidationMessage"
     | "updateNorthboundConnection"
     | "updateContributeCatalog"
+    | "updateJsonIndentation"
   >;
 
   type Action =
@@ -160,7 +161,6 @@ declare global {
     northboundUrl: string;
     southboundUrl: string;
     pathToValue: string;
-    jsonIndentation: 2 | 4;
   }
 
   // Define the shape of the state


### PR DESCRIPTION
- Added new 'JSON Editor' section in Settings
- Introduced jsonIndentation (2 | 4) in SettingsData
- Connected indentation setting to Monaco editor tabSize
- Auto-format JSON using selected indentation
- Prevent infinite formatting loop
- Apply changes immediately after saving settings

Closes #185