### PR TITLE
feat: add toggle button to show/hide Monaco editor (#206)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,12 +185,18 @@ const App: React.FC = () => {
           {doShowJSON && (
             <>
               <Bar
-                size={7.5}
-                className="cursor-col-resize bg-gray-300 hover:bg-blue-500"
+                size={doShowJSON ? 7.5 : 0}
+                className={`cursor-col-resize bg-gray-300 hover:bg-blue-500 ${
+                  doShowJSON ? "" : "hidden"
+                }`}
               />
 
-              <Section className="w-full md:w-5/12">
-                <JsonEditor editorRef={editorRef} />
+              <Section
+                className={`w-full ${
+                  doShowJSON ? "md:w-5/12" : "md:w-0"
+                } overflow-hidden`}
+              >
+                {doShowJSON && <JsonEditor editorRef={editorRef} />}
               </Section>
             </>
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,10 +163,7 @@ const App: React.FC = () => {
 
   return (
     <main className="flex max-h-screen w-screen flex-col">
-      <AppHeader
-        onToggleJSON={handleToggleJSON}
-        isJSONVisible={doShowJSON}
-      />
+      <AppHeader onToggleJSON={handleToggleJSON} isJSONVisible={doShowJSON} />
 
       <div className="">
         <Container className="height-adjust flex flex-col md:flex-row">
@@ -197,7 +194,6 @@ const App: React.FC = () => {
               </Section>
             </>
           )}
-
         </Container>
       </div>
       <div className="fixed bottom-0 w-screen">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,8 @@ import "./App.css";
 import AppFooter from "./components/App/AppFooter";
 import AppHeader from "./components/App/AppHeader";
 import { Container, Section, Bar } from "@column-resizer/react";
-import { RefreshCw } from "react-feather";
 import { decompressSharedTd } from "./share";
 import { editor } from "monaco-editor";
-import BaseButton from "./components/TDViewer/base/BaseButton";
 import ErrorDialog from "./components/Dialogs/ErrorDialog";
 
 const GlobalStateWrapper = () => {
@@ -46,7 +44,7 @@ const App: React.FC = () => {
   const context = useContext(ediTDorContext);
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
-  const [doShowJSON, setDoShowJSON] = useState(false);
+  const [doShowJSON, setDoShowJSON] = useState(true);
   const [customBreakpointsState, setCustomBreakpointsState] = useState(0);
   const tdViewerRef = useRef<HTMLDivElement>(null);
 
@@ -165,11 +163,19 @@ const App: React.FC = () => {
 
   return (
     <main className="flex max-h-screen w-screen flex-col">
-      <AppHeader></AppHeader>
+      <AppHeader
+        onToggleJSON={handleToggleJSON}
+        isJSONVisible={doShowJSON}
+      />
 
       <div className="">
         <Container className="height-adjust flex flex-col md:flex-row">
-          <Section minSize={550} className="w-full min-w-16 md:w-7/12">
+          <Section
+            minSize={550}
+            className={`w-full min-w-16 ${
+              doShowJSON ? "md:w-7/12" : "md:w-full"
+            }`}
+          >
             <div ref={tdViewerRef} className="h-full w-full">
               <TDViewer
                 onUndo={handleUndo}
@@ -179,23 +185,19 @@ const App: React.FC = () => {
             </div>
           </Section>
 
-          <Bar
-            size={7.5}
-            className="cursor-col-resize bg-gray-300 hover:bg-blue-500"
-          />
+          {doShowJSON && (
+            <>
+              <Bar
+                size={7.5}
+                className="cursor-col-resize bg-gray-300 hover:bg-blue-500"
+              />
 
-          <Section className="w-full md:w-5/12">
-            <JsonEditor editorRef={editorRef} />
-          </Section>
+              <Section className="w-full md:w-5/12">
+                <JsonEditor editorRef={editorRef} />
+              </Section>
+            </>
+          )}
 
-          <BaseButton
-            type="button"
-            className="fixed bottom-12 right-2 z-10 rounded-full bg-blue-500 p-4"
-            onClick={handleToggleJSON}
-            variant="empty"
-          >
-            <RefreshCw color="white" />
-          </BaseButton>
         </Container>
       </div>
       <div className="fixed bottom-0 w-screen">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ const App: React.FC = () => {
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const [doShowJSON, setDoShowJSON] = useState(true);
+  const [containerKey, setContainerKey] = useState(0);
   const [customBreakpointsState, setCustomBreakpointsState] = useState(0);
   const tdViewerRef = useRef<HTMLDivElement>(null);
 
@@ -74,6 +75,7 @@ const App: React.FC = () => {
 
   const handleToggleJSON = () => {
     setDoShowJSON((prev) => !prev);
+    setContainerKey((prev) => prev + 1);
   };
 
   useEffect(() => {
@@ -166,7 +168,7 @@ const App: React.FC = () => {
       <AppHeader onToggleJSON={handleToggleJSON} isJSONVisible={doShowJSON} />
 
       <div className="">
-        <Container className="height-adjust flex flex-col md:flex-row">
+        <Container key={containerKey} className="height-adjust flex flex-col md:flex-row">
           <Section
             minSize={550}
             className={`w-full min-w-16 ${

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,7 +168,10 @@ const App: React.FC = () => {
       <AppHeader onToggleJSON={handleToggleJSON} isJSONVisible={doShowJSON} />
 
       <div className="">
-        <Container key={containerKey} className="height-adjust flex flex-col md:flex-row">
+        <Container
+          key={containerKey}
+          className="height-adjust flex flex-col md:flex-row"
+        >
           <Section
             minSize={550}
             className={`w-full min-w-16 ${

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ const App: React.FC = () => {
 
     resizeObserver.observe(tdViewerRef.current);
     return () => resizeObserver.disconnect();
-  }, []);
+  }, [containerKey]);
 
   return (
     <main className="flex max-h-screen w-screen flex-col">
@@ -174,9 +174,8 @@ const App: React.FC = () => {
         >
           <Section
             minSize={550}
-            className={`w-full min-w-16 ${
-              doShowJSON ? "md:w-7/12" : "md:w-full"
-            }`}
+            className={`w-full min-w-16 ${doShowJSON ? "md:w-7/12" : "md:w-full"
+              }`}
           >
             <div ref={tdViewerRef} className="h-full w-full">
               <TDViewer
@@ -191,15 +190,13 @@ const App: React.FC = () => {
             <>
               <Bar
                 size={doShowJSON ? 7.5 : 0}
-                className={`cursor-col-resize bg-gray-300 hover:bg-blue-500 ${
-                  doShowJSON ? "" : "hidden"
-                }`}
+                className={`cursor-col-resize bg-gray-300 hover:bg-blue-500 ${doShowJSON ? "" : "hidden"
+                  }`}
               />
 
               <Section
-                className={`w-full ${
-                  doShowJSON ? "md:w-5/12" : "md:w-0"
-                } overflow-hidden`}
+                className={`w-full ${doShowJSON ? "md:w-5/12" : "md:w-0"
+                  } overflow-hidden`}
               >
                 {doShowJSON && <JsonEditor editorRef={editorRef} />}
               </Section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -248,8 +248,9 @@ const App = () => {
         >
           <Section
             minSize={550}
-            className={`w-full min-w-16 ${doShowJSON ? "md:w-7/12" : "md:w-full"
-              }`}
+            className={`w-full min-w-16 ${
+              doShowJSON ? "md:w-7/12" : "md:w-full"
+            }`}
           >
             <div ref={tdViewerRef} className="h-full w-full">
               <TDViewer
@@ -264,13 +265,15 @@ const App = () => {
             <>
               <Bar
                 size={doShowJSON ? 7.5 : 0}
-                className={`cursor-col-resize bg-gray-300 hover:bg-blue-500 ${doShowJSON ? "" : "hidden"
-                  }`}
+                className={`cursor-col-resize bg-gray-300 hover:bg-blue-500 ${
+                  doShowJSON ? "" : "hidden"
+                }`}
               />
 
               <Section
-                className={`w-full ${doShowJSON ? "md:w-5/12" : "md:w-0"
-                  } overflow-hidden`}
+                className={`w-full ${
+                  doShowJSON ? "md:w-5/12" : "md:w-0"
+                } overflow-hidden`}
               >
                 {doShowJSON && <JsonEditor editorRef={editorRef} />}
               </Section>

--- a/src/components/App/AppHeader.tsx
+++ b/src/components/App/AppHeader.tsx
@@ -26,6 +26,8 @@ import {
   Share,
   Link,
   Send,
+  Eye,
+  EyeOff,
 } from "react-feather";
 import editdorLogo from "../../assets/editdor.png";
 import ediTDorContext from "../../context/ediTDorContext";
@@ -49,7 +51,10 @@ const INVALID_TYPE_MESSAGE =
 const VALIDATION_FAILED_MESSAGE =
   "The Thing Model did not pass the JSON schema validation Please make sure the Thing Model is valid according to the JSON schema before contributing it to the catalog.";
 
-const AppHeader: React.FC = () => {
+const AppHeader: React.FC<{
+  onToggleJSON: () => void;
+  isJSONVisible: boolean;
+}> = ({ onToggleJSON, isJSONVisible }) => {
   const context = useContext(ediTDorContext);
   const td: ThingDescription = context.parsedTD;
   /** States*/
@@ -334,6 +339,12 @@ const AppHeader: React.FC = () => {
           <Button onClick={handleOpenSettingsDialog}>
             <Settings />
             <div className="text-xs">Settings</div>
+          </Button>
+          <Button onClick={onToggleJSON}>
+            {isJSONVisible ? <EyeOff /> : <Eye />}
+            <div className="text-xs">
+              {isJSONVisible ? "Hide Code" : "Show Code"}
+            </div>
           </Button>
         </div>
       </header>


### PR DESCRIPTION
## Summary

This PR implements a toggle button to show/hide the Monaco JSON editor as requested in #206.

## Changes

- Added a toggle button in the header (next to Settings)
- Conditionally render the Monaco editor and resize bar
- Automatically expand TDViewer to full width when editor is hidden
- Removed the previous floating toggle button
- Kept layout responsive and consistent with existing design

## Behavior

- Clicking "Hide Code" hides the Monaco editor and expands the left view
- Clicking "Show Code" restores the editor and split layout
- No impact on undo/redo, validation, or existing functionality

## Screenshots

### Editor Visible :
<img width="1920" height="974" alt="image" src="https://github.com/user-attachments/assets/96d41c00-7997-4229-bb73-7addf421fb3d" />

### Editor Hidden :
<img width="1919" height="976" alt="image" src="https://github.com/user-attachments/assets/7a4ffd73-6852-41ed-80cc-ba0c32d48b8c" />

## Testing

- Verified layout responsiveness
- Verified no console errors
- Verified undo/redo still works
- Verified build succeeds (`npm run build`)

